### PR TITLE
Use direct HTTP request to load the page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+.DS_Store

--- a/obp-access.gemspec
+++ b/obp-access.gemspec
@@ -25,7 +25,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ferrum"
   spec.add_dependency "nokogiri"
-  spec.add_dependency "base64"
 end


### PR DESCRIPTION
### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required
 - [ ] External dependency introduced
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->

___

Guys, you don't need a freaking browser to load a single page.

This is a simplified example. Normally, you would introduce a proper HTTP client (external gem or wrapper around `net/http`), request retries, response validations, user agent injection (this website doesn't care really), cookie injection (technically, they use `JSESSIONID` but it does nothing and can be skipped) and other standard stuff.
