### PR TITLE
Make `to_xml` & `to_sts` methods available

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,9 +28,11 @@ There are many situations where the informative content is already useful:
 
 === Usage
 
-[source,sh]
+[source,ruby]
 ----
-bundle exec exe/obp-access -o output iso:std:iso:5598:ed-3:v1:en
+obp = Obp::Access.fetch("iso:std:iso:...") # => #<Obp::Access::Parser @urn="iso:std:iso:...">
+obp.to_xml(pretty: true) # => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>..."
+obp.to_sts # => #<Sts::NisoSts::Standard>
 ----
 
 == Credits

--- a/lib/obp-access.rb
+++ b/lib/obp-access.rb
@@ -1,2 +1,1 @@
-require "obp/access/version"
 require "obp/access"

--- a/lib/obp/access.rb
+++ b/lib/obp/access.rb
@@ -1,42 +1,14 @@
 require "obp/access/parser"
 require "obp/access/converter"
 require "obp/access/rendered"
-require "optparse"
-require "net/http"
-require "nokogiri"
-require "json"
-require "yaml"
-require "fileutils"
+require "obp/access/version"
 
 module Obp
   module Access
-    def self.start
-      Obp::Access::Parser.start(options)
-    end
+    def self.fetch(urn = nil)
+      raise ArgumentError.new("URN is required. Please pass it as an argument") unless urn
 
-    def self.options
-      options = {}
-
-      OptionParser.new do |opts|
-        opts.banner = "Usage: obp-access.rb [options] URN"
-
-        opts.on("-oOUTPUT", "--output=OUTPUT", "The output directory") do |o|
-          options[:output] = o
-        end
-      end.parse!
-
-      options[:urn] = ARGV.pop
-
-      unless options[:output]
-        raise OptionParser::MissingArgument,
-              "Output folder is required. Please specify using -o or --output."
-      end
-      unless options[:urn]
-        raise OptionParser::MissingArgument,
-              "URN is required. Please pass it as an argument"
-      end
-
-      options
+      Obp::Access::Parser.new(urn)
     end
   end
 end

--- a/lib/obp/access/parser.rb
+++ b/lib/obp/access/parser.rb
@@ -1,3 +1,8 @@
+require "net/http"
+require "nokogiri"
+require "json"
+require "sts"
+
 module Obp
   module Access
     class Parser
@@ -6,125 +11,50 @@ module Obp
 
       IMAGE_FOLDER = "images".freeze
 
-      attr_reader :options
+      attr_reader :urn
 
-      def self.start(options)
-        new(options).start
+      def initialize(urn)
+        @urn = urn
       end
 
-      def initialize(options)
-        @options = options
+      def to_xml(pretty: false)
+        pretty ? pretty_print_xml(xml) : xml
       end
 
-      def start
-        @state = parse_state
-
-        puts "[obp-access] writing output..."
-
-        xml_content = convert_html_to_xml
-        xml_content = pretty_print_xml(xml_content) # FIXME: Remove pretty printing
-        file_path = File.join(options[:output], "#{options[:urn]}.xml")
-        File.write(file_path, xml_content)
-
-        puts "[obp-access] output written to `#{file_path}`"
+      def to_sts
+        Sts::NisoSts::Standard.from_xml(xml)
       end
 
       private
 
-      def title
-        @title ||= @state.filter_map do |attr|
-          attr.dig("pageState", "title")
-        end.first.split(",").last
-      end
+      def state
+        @state ||= begin
+          ui_response = load_ui_response
+          ui_json     = JSON.parse(ui_response.body)
+          state_json  = JSON.parse(ui_json["uidl"])
 
-      def identifier
-        @identifier ||= @state.detect do |attr|
-          attr["styles"]&.first == "h2"
-        end["text"]
-      end
-
-      def render_html(source_html)
-        Nokogiri::HTML5::Document.parse <<-EOHTML
-        <!DOCTYPE html>
-        <html>
-          <head>
-            <title>#{identifier}: #{title}</title>
-            <meta charset="UTF-8">
-          </head>
-          <body>
-          #{source_html}
-          </body>
-        </html>
-        EOHTML
-      end
-
-      def page
-        @page ||= begin
-          source_html = @state.filter_map { |attr| attr["htmlContent"] }.first
-          render_html(source_html)
+          state_json["state"].values
         end
       end
 
-      def prepare_output_folders
-        FileUtils.mkdir_p("#{options[:output]}/#{IMAGE_FOLDER}") # root folder will be created automatically
-      end
-
-      def write_metadata
-        metadata = {
-          "scrape_date" => Time.now.utc,
-          "identifier" => identifier,
-          "title" => title,
-          "urn" => options[:urn],
-        }.to_yaml
-
-        File.write("#{options[:output]}/metadata.yml", metadata)
-      end
-
-      def write_images_and_patch_links
-        images = page.xpath("//div[contains(@class, 'sts-standard')]//img")
-        images.each do |img|
-          filename = File.basename(img["src"])
-          subpath = "#{IMAGE_FOLDER}/#{filename}"
-
-          image_blob = load_image_blob(img["src"])
-          File.write("#{options[:output]}/#{subpath}", image_blob, mode: "wb")
-
-          img["src"] = subpath
-        end
-      end
-
-      def write_page_html
-        File.write("#{options[:output]}/index.html", page.to_html)
-      end
-
-      def parse_state
-        ui_response = load_ui_response
-        ui_json     = JSON.parse(ui_response.body)
-        state_json  = JSON.parse(ui_json["uidl"])
-
-        state_json["state"].values
+      def xml
+        @xml ||= convert_html_to_xml
       end
 
       def load_ui_response
         payload = {
           "v-browserDetails" => 1,
           "theme" => "iso-red",
-          "v-loc" => "#{API_URL}##{options[:urn]}",
+          "v-loc" => "#{API_URL}##{urn}",
         }
 
         Net::HTTP.post_form(URI(API_URL), payload)
       end
 
-      def load_image_blob(image_href)
-        image_url = "#{BASE_URL}#{image_href}"
-
-        Net::HTTP.get_response(URI(image_url)).body
-      end
-
       def convert_html_to_xml
-        html = @state.filter_map { |attr| attr["htmlContent"] }.first
-        metas = @state.filter_map { |attr| attr["tabs"] }.first.last
-        converter = Converter.new(urn: options[:urn], metas:, source: html)
+        html = state.filter_map { |attr| attr["htmlContent"] }.first
+        metas = state.filter_map { |attr| attr["tabs"] }.first.last
+        converter = Converter.new(urn: urn, metas:, source: html)
         converter.to_xml
       end
 
@@ -132,6 +62,25 @@ module Obp
         doc = Nokogiri::XML(xml_content, &:noblanks)
         doc.to_xml
       end
+
+      # def write_images_and_patch_links
+      #   images = page.xpath("//div[contains(@class, 'sts-standard')]//img")
+      #   images.each do |img|
+      #     filename = File.basename(img["src"])
+      #     subpath = "#{IMAGE_FOLDER}/#{filename}"
+      #
+      #     image_blob = load_image_blob(img["src"])
+      #     File.write("#{options[:output]}/#{subpath}", image_blob, mode: "wb")
+      #
+      #     img["src"] = subpath
+      #   end
+      # end
+      #
+      # def load_image_blob(image_href)
+      #   image_url = "#{BASE_URL}#{image_href}"
+      #
+      #   Net::HTTP.get_response(URI(image_url)).body
+      # end
     end
   end
 end

--- a/obp-access.gemspec
+++ b/obp-access.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_dependency "nokogiri"
+  spec.add_dependency "sts"
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
### Adds the following

 -  Add `to_xml` method, with optional `pretty: true` parameter
 - Add `to_sts` method, to return a `Sts::NisoSts::Standard` instance
 - Update the README
