### PR TITLE
Add multilingual support with grammar/domain extraction and comprehensive test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Gemfile.lock
 obp-access-*.gem
 .rubocop-https---raw-githubusercontent-com-riboseinc-oss-guides-master-ci-rubocop-yml
 .rspec_status
+obp-output/
+TODO.multilingual/
+*.xml
+!spec/fixtures/*.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Ruby gem (`obp-access`) that fetches informative content (introduction, scope, terms, bibliography) from the ISO Online Browsing Platform (OBP) and converts it to NISO STS XML. Published by Ribose Inc. under BSD-2-Clause license.
+
+## Commands
+
+- **Install dependencies:** `bundle install`
+- **Run tests:** `bundle exec rake test` (uses test-unit framework, tests in `test/`)
+- **Lint:** `bundle exec rubocop`
+- **Run a single test:** `ruby -Ilib -Itest test/test_something.rb`
+- **Console:** `bin/console` (loads the gem for interactive use)
+
+## Architecture
+
+Data flows through four main classes in `lib/obp/access/`:
+
+1. **`Access`** (entry point) — orchestrates the pipeline. `Obp::Access.fetch(urn)` returns an instance that can produce XML (`to_xml`), STS objects (`to_sts`), or XML files (`to_xml_file`).
+
+2. **`Parser`** — fetches content from the ISO OBP API (`https://www.iso.org/obp/ui`) via HTTP POST with a URN payload. Parses the JSON response to extract HTML content, titles (parallelized across languages), and images.
+
+3. **`Converter`** — wraps the HTML source, normalizes whitespace, parses it with Nokogiri, and passes the DOM nodes to the Renderer.
+
+4. **`Renderer`** — recursively walks DOM nodes and dispatches them to element classes (subclasses of `Elements::Base` in `lib/obp/access/elements/`). Each element class matches against CSS classes on the DOM node and builds NISO STS XML via `Nokogiri::XML::Builder`.
+
+### Element system
+
+- **`Elements::Base`** — abstract base class. Subclasses implement `self.classes` (CSS class array to match) and `content` (XML builder). The `render` method inserts the built XML into the document at a target path.
+- **`Elements::Root`** — creates the NISO STS document skeleton (`<standard>` with `<front>`, `<body>`, `<back>`).
+- **`Elements::Terminology`** and its sub-elements (`definition`, `note`, `source`, `example`, `tig`, `tig_preferred`, `tig_admitted`) handle term entries using the `tbx:` namespace.
+- Other elements: `section`, `introduction`, `bibliography`, `paragraph`, `list`, `array`, `figure`, `figure_group`, `table_wrap`, `title`, `copyright`.
+
+`Renderer.elements` discovers all `Elements::Base` subclasses at runtime via `ObjectSpace`, so adding a new element class (that inherits from `Base`) automatically includes it in rendering.
+
+### Supporting classes
+
+- **`Imager`** — downloads images from OBP and saves them locally. Uses `Parallel` for concurrent downloads.
+
+## Key dependencies
+
+- **nokogiri** — HTML/XML parsing and building
+- **parallel** — concurrent HTTP requests (title fetching, image downloads)
+- **sts** — NISO STS gem for generating STS objects from XML
+
+## Testing
+
+Test fixtures are HTML snapshots in `spec/fixtures/`. The `spec/` directory currently only contains fixtures; `test/` is the test directory but has no test files yet. The Rake default task runs `rake test`.
+
+## Ruby version
+
+Requires Ruby >= 3.1.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "sts", path: "../sts-ruby"
+gem "sts", path: "../sts-ruby" if Dir.exist?("../sts-ruby")
 
 group :development do
   gem "rake"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "sts", path: "../sts-ruby"
+
 group :development do
   gem "rake"
   gem "rubocop", require: false

--- a/README.adoc
+++ b/README.adoc
@@ -28,13 +28,63 @@ There are many situations where the informative content is already useful:
 
 === Usage
 
+==== Single language
+
 [source,ruby]
 ----
-obp = Obp::Access.fetch("iso:std:iso:...") # => #<Obp::Access @urn="iso:std:iso:...">
-obp.to_xml(pretty: true) # => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>..."
-obp.to_sts # => #<Sts::NisoSts::Standard>
-obp.to_xml_file # > "/tmp/iso-std-iso-[...]-20250102-26793-czvdyo/iso-std-iso-[...].xml"
+obp = Obp::Access.fetch("iso:std:iso:5598:ed-3:v1:en")
+obp.to_xml(pretty: true) # => NISO STS XML string
+obp.to_sts               # => #<Sts::NisoSts::Standard>
+obp.to_xml_file          # => "/tmp/iso-std-iso-5598-.../iso-std-iso-5598-....xml"
 ----
+
+==== Multilingual (specific languages)
+
+[source,ruby]
+----
+obp = Obp::Access.fetch("iso:std:iso:5598:ed-3:v1:en", languages: ["fr", "de"])
+obp.to_xml(pretty: true) # => NISO STS XML with en/fr/de langSets
+----
+
+==== Multilingual (all available languages)
+
+[source,ruby]
+----
+obp = Obp::Access.fetch("iso:std:iso:5598:ed-3:v1:en", languages: :all)
+obp.to_xml(pretty: true) # => NISO STS XML with all available language langSets
+----
+
+==== CLI
+
+Fetch a single document (English only):
+
+[source,shell]
+----
+$ obp-access fetch iso:std:iso:5598:ed-3:v1:en
+----
+
+Fetch with all available languages:
+
+[source,shell]
+----
+$ obp-access fetch -l all iso:std:iso:5598:ed-3:v1:en
+----
+
+Fetch with specific languages and save to file:
+
+[source,shell]
+----
+$ obp-access fetch -l fr,de -o output/ iso:std:iso:5598:ed-3:v1:en
+----
+
+=== Generated XML
+
+The output is NISO STS XML with TBX-Basic terminology markup:
+
+* Terms use `<tbx:termEntry>` with `<tbx:langSet>` per language
+* Grammar is encoded via `<tbx:gram>` (gender: m/f/n) and `<tbx:partOfSpeech>`
+* Domains are extracted as `<tbx:subjectField>`
+* Deprecated terms use `<tbx:normativeAuthorization value="deprecatedTerm"/>`
 
 == Credits
 

--- a/exe/obp-access
+++ b/exe/obp-access
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require "obp-access"
+require "obp/access"
 
-Obp::Access.start
+Obp::Access::CLI.start(ARGV)

--- a/lib/obp/access.rb
+++ b/lib/obp/access.rb
@@ -1,14 +1,53 @@
+require "tmpdir"
 require "net/http"
 require "nokogiri"
 require "json"
+require "lutaml/model"
 require "sts"
 require "parallel"
 
-require "obp/access/parser"
-require "obp/access/converter"
-require "obp/access/imager"
-require "obp/access/renderer"
-require "obp/access/version"
+require_relative "access/urn"
+require_relative "access/inline_renderer"
+require_relative "access/grammar_parser"
+require_relative "access/domain_extractor"
+require_relative "access/multilingual_merger"
+require_relative "access/deliverable"
+require_relative "access/catalog"
+require_relative "access/retriever"
+require_relative "access/fetcher"
+require_relative "access/element_registry"
+require_relative "access/parser"
+require_relative "access/converter"
+require_relative "access/imager"
+require_relative "access/renderer"
+require_relative "access/cli"
+
+require_relative "access/elements/base"
+require_relative "access/elements/root"
+require_relative "access/elements/introduction"
+require_relative "access/elements/index"
+require_relative "access/elements/section"
+require_relative "access/elements/figure"
+require_relative "access/elements/figure_group"
+require_relative "access/elements/list"
+require_relative "access/elements/array"
+require_relative "access/elements/table_wrap"
+require_relative "access/elements/title"
+require_relative "access/elements/paragraph"
+require_relative "access/elements/non_normative_note"
+require_relative "access/elements/copyright"
+require_relative "access/elements/bibliography"
+require_relative "access/elements/terminology"
+require_relative "access/elements/terminology/base"
+require_relative "access/elements/terminology/definition"
+require_relative "access/elements/terminology/note"
+require_relative "access/elements/terminology/tig"
+require_relative "access/elements/terminology/tig_admitted"
+require_relative "access/elements/terminology/tig_preferred"
+require_relative "access/elements/terminology/tig_deprecated"
+require_relative "access/elements/terminology/example"
+require_relative "access/elements/terminology/source"
+require_relative "access/version"
 
 module Obp
   class Access
@@ -17,51 +56,83 @@ module Obp
 
     attr_reader :urn
 
-    def self.fetch(urn = nil)
-      raise ArgumentError.new("URN is required. Please pass it as an argument") unless urn
+    def self.fetch(urn, languages: nil)
+      raise ArgumentError, "URN is required" unless urn
 
-      Obp::Access.new(urn)
+      new(Urn.new(urn), languages:)
     end
 
-    def initialize(urn)
+    def initialize(urn, languages: nil)
       @urn = urn
+      @languages = languages
     end
 
     def to_xml(pretty: false)
-      pretty ? pretty_print_xml : xml
+      xml = primary_xml
+      xml = merge_translations(xml) if multilingual?
+      pretty ? pretty_print(xml) : xml
     end
 
     def to_sts
-      Sts::NisoSts::Standard.from_xml(xml)
+      Sts::NisoSts::Standard.from_xml(to_xml)
     end
 
     def to_xml_file
-      file_path = File.join(tmpdir, "#{urn_safe}.xml")
-      File.write(file_path, pretty_print_xml)
-      file_path
+      path = File.join(tmpdir, "#{urn.safe}.xml")
+      File.write(path, to_xml(pretty: true))
+      path
     end
 
     private
 
+    def primary_xml
+      @primary_xml ||= parser.to_xml
+    end
+
     def parser
-      @parser ||= Obp::Access::Parser.new(urn:, directory: tmpdir)
+      @parser ||= Parser.new(urn:, directory: tmpdir)
     end
 
-    def xml
-      parser.to_xml
+    def multilingual?
+      resolved_languages.size > 1
     end
 
-    def pretty_print_xml
-      doc = Nokogiri::XML(xml, &:noblanks)
-      doc.to_xml
+    def resolved_languages
+      @resolved_languages ||= begin
+        available = parser.available_languages
+        case @languages
+        when nil then [urn.language]
+        when :all then [urn.language] | available
+        when Array then [urn.language] | (@languages & available)
+        end
+      end
+    end
+
+    def additional_languages
+      resolved_languages - [urn.language]
+    end
+
+    def merge_translations(xml)
+      document = Nokogiri::XML(xml)
+      additional_sources = fetch_additional_sources
+      MultilingualMerger.new(document, additional_sources, {}).merge
+      document.to_xml
+    end
+
+    def fetch_additional_sources
+      Parallel.map(additional_languages) do |lang|
+        other_urn = Urn.new("#{urn.base}:#{lang}")
+        other_parser = Parser.new(urn: other_urn, directory: tmpdir)
+        [lang, other_parser.html]
+      end.to_h
+    end
+
+    def pretty_print(xml)
+      Nokogiri::XML(xml, &:noblanks).to_xml
     end
 
     def tmpdir
-      @tmpdir ||= Dir.mktmpdir(urn_safe)
-    end
-
-    def urn_safe
-      @urn_safe ||= urn.tr(":", "-") # Convert urn : to - for non-unix system compatibility
+      @tmpdir ||= Dir.mktmpdir(urn.safe)
     end
   end
 end

--- a/lib/obp/access/catalog.rb
+++ b/lib/obp/access/catalog.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+
+module Obp
+  class Access
+    class Catalog
+      SOURCE_URL = "https://isopublicstorageprod.blob.core.windows.net/opendata/" \
+                   "_latest/iso_deliverables_metadata/json/iso_deliverables_metadata.jsonl"
+
+      attr_reader :deliverables
+
+      def initialize(deliverables:)
+        @deliverables = deliverables
+      end
+
+      def self.load(path: nil, url: SOURCE_URL)
+        raw = path ? read_local(path) : fetch_remote(url)
+        new(deliverables: parse_jsonl(raw).map { |data| Deliverable.new(data) })
+      end
+
+      def retrievable
+        @retrievable ||= deliverables.select(&:retrievable?)
+      end
+
+      def by_type(type)
+        deliverables.select { |d| d.deliverable_type == type }
+      end
+
+      def by_ics(code)
+        deliverables.select { |d| d.ics_codes.include?(code) }
+      end
+
+      def count
+        deliverables.size
+      end
+
+      class << self
+        private
+
+        def parse_jsonl(text)
+          text.lines.filter_map do |line|
+            line.strip!
+            next if line.empty?
+
+            JSON.parse(line)
+          end
+        end
+
+        def read_local(path)
+          File.read(path)
+        end
+
+        def fetch_remote(url)
+          uri = URI(url)
+          response = Net::HTTP.get_response(uri)
+          unless response.is_a?(Net::HTTPSuccess)
+            raise "Failed to fetch catalog: #{response.code} #{response.message}"
+          end
+
+          response.body
+        end
+      end
+    end
+  end
+end

--- a/lib/obp/access/cli.rb
+++ b/lib/obp/access/cli.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "thor"
+
+module Obp
+  class Access
+    class CLI < Thor
+      desc "fetch URN", "Fetch a single document from ISO OBP by URN"
+      option :output, aliases: "-o", type: :string, desc: "Output directory (default: stdout)"
+      option :languages, aliases: "-l", type: :string,
+                         desc: "Languages: 'all' or comma-separated (e.g. 'fr,de')"
+      def fetch(urn)
+        say "Fetching #{urn}..."
+        access = Access.fetch(urn, languages: parse_languages)
+        output(access)
+      rescue StandardError => e
+        say "Error: #{e.message}", :red
+        exit 1
+      end
+
+      desc "catalog", "Load and inspect the ISO Open Data catalog"
+      option :path, type: :string, desc: "Local JSONL file path (default: fetch remote)"
+      option :filter, type: :string, enum: %w[retrievable types], desc: "Filter mode"
+      option :type, type: :string, desc: "Filter by deliverable type (IS, TS, TR, etc.)"
+      option :ics, type: :string, desc: "Filter by ICS code"
+      def catalog
+        say "Loading catalog..."
+        cat = Access::Catalog.load(path: options[:path])
+
+        if options[:filter] == "types"
+          print_type_summary(cat)
+          return
+        end
+
+        print_deliverables(cat)
+      rescue StandardError => e
+        say "Error: #{e.message}", :red
+        exit 1
+      end
+
+      desc "retrieve", "Bulk retrieve documents from ISO OBP"
+      option :output, aliases: "-o", type: :string, required: true, desc: "Output directory"
+      option :path, type: :string, desc: "Local JSONL file path"
+      option :concurrency, aliases: "-c", type: :numeric, default: 4, desc: "Thread concurrency"
+      def retrieve
+        say "Loading catalog..."
+        cat = Access::Catalog.load(path: options[:path])
+        say "Found #{cat.retrievable.size} retrievable deliverables"
+        build_retriever(cat).run
+      rescue StandardError => e
+        say "Error: #{e.message}", :red
+        exit 1
+      end
+
+      private
+
+      def output(access)
+        if options[:output]
+          dir = File.expand_path(options[:output])
+          FileUtils.mkdir_p(dir)
+          path = File.join(dir, "#{access.urn.safe}.xml")
+          File.write(path, access.to_xml(pretty: true))
+          say "Saved to #{path}", :green
+        else
+          puts access.to_xml(pretty: true)
+        end
+      end
+
+      def print_deliverables(cat)
+        filtered = apply_filters(cat)
+        say "Total: #{filtered.size} deliverables"
+        filtered.first(20).each do |d|
+          say "  #{d.reference} [#{d.deliverable_type}] stage=#{d.current_stage} langs=#{d.languages.join(',')}"
+        end
+        say "  ... (showing first 20)" if filtered.size > 20
+      end
+
+      def apply_filters(cat)
+        return cat.by_type(options[:type]) if options[:type]
+        return cat.by_ics(options[:ics]) if options[:ics]
+        return cat.retrievable if options[:filter] == "retrievable"
+
+        cat.deliverables
+      end
+
+      def build_retriever(cat)
+        Access::Retriever.new(
+          output_dir: File.expand_path(options[:output]),
+          catalog: cat,
+          concurrency: options[:concurrency],
+        )
+      end
+
+      def parse_languages
+        case options[:languages]
+        when nil then nil
+        when "all" then :all
+        else options[:languages].split(",").map(&:strip)
+        end
+      end
+
+      def print_type_summary(cat)
+        cat.deliverables.group_by(&:deliverable_type).sort.each do |type, list|
+          published = list.count(&:published?)
+          say "  #{type || 'IS'}: #{list.size} total, #{published} published"
+        end
+      end
+    end
+  end
+end

--- a/lib/obp/access/converter.rb
+++ b/lib/obp/access/converter.rb
@@ -10,14 +10,13 @@ module Obp
       end
 
       def to_xml
-        rendered = Renderer.new(urn:, metas:, nodes:)
-        rendered.to_xml
+        Renderer.new(urn:, metas:, nodes:).to_xml
       end
 
       private
 
       def nodes
-        html = source.gsub(/[[:space:]]/, " ") # Convert NBSP to spaces from html
+        html = source.gsub(/[[:space:]]/, " ")
         doc = Nokogiri::HTML(html)
         doc.css("body > div.sts-standard").children
       end

--- a/lib/obp/access/deliverable.rb
+++ b/lib/obp/access/deliverable.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Obp
+  class Access
+    class Deliverable
+      TYPE_SEGMENTS = {
+        "IS" => nil, "TS" => "ts", "TR" => "tr", "R" => "r",
+        "PAS" => "pas", "ISP" => "isp", "GUIDE" => "guide",
+        "IWA" => "iwa", "DATA" => "data", "TTA" => "tta"
+      }.freeze
+
+      TYPE_WORDS = Set.new(TYPE_SEGMENTS.compact.keys).freeze
+
+      PUBLISHED_STAGES = [6060, 9092].freeze
+
+      attr_reader :id, :reference, :deliverable_type, :edition, :current_stage,
+                  :languages, :supplement_type, :title, :publication_date,
+                  :ics_codes, :owner_committee
+
+      def initialize(data)
+        @id = data["id"]
+        assign_metadata(data)
+      end
+
+      def published?
+        PUBLISHED_STAGES.include?(current_stage)
+      end
+
+      def base_document?
+        supplement_type.nil?
+      end
+
+      def retrievable?
+        published? && base_document? && languages.any?
+      end
+
+      def to_urn(language: "en")
+        Urn.new(build_urn(language))
+      end
+
+      def english_title
+        title["en"]
+      end
+
+      private
+
+      def assign_metadata(data)
+        @reference = data["reference"]
+        @deliverable_type = data["deliverableType"]
+        @edition = data["edition"]
+        @current_stage = data["currentStage"]
+        @supplement_type = data["supplementType"]
+        @publication_date = data["publicationDate"]
+        @owner_committee = data["ownerCommittee"]
+        assign_collections(data)
+      end
+
+      def assign_collections(data)
+        @languages = Array(data["languages"])
+        @title = data["title"] || {}
+        @ics_codes = Array(data["icsCode"])
+      end
+
+      def build_urn(language)
+        segs = ["iso", "std", org_segment]
+        type_seg = TYPE_SEGMENTS[deliverable_type]
+        segs << type_seg if type_seg
+        segs << extract_number
+        segs << "-#{extract_part}" if extract_part
+        segs << "ed-#{edition}"
+        segs << "v1"
+        segs << language
+        segs.join(":")
+      end
+
+      def org_segment
+        @org_segment ||= begin
+          tokens = parse_prefix_tokens
+          rest = tokens[1..] || []
+          org_tokens = rest.reject { |t| TYPE_WORDS.include?(t) }
+          org_tokens.empty? ? "iso" : "iso-#{org_tokens.join('-').downcase}"
+        end
+      end
+
+      def extract_number
+        @extract_number ||= begin
+          match = base_reference.match(/(\d+)(?:-\d+)?:\d{4}/)
+          match ? match[1] : "0"
+        end
+      end
+
+      def extract_part
+        @extract_part ||= begin
+          match = base_reference.match(/\d+-(\d+):\d{4}/)
+          match ? match[1] : nil
+        end
+      end
+
+      def parse_prefix_tokens
+        prefix = base_reference.match(/\A(.+?)\s+\d/)&.[](1) || "ISO"
+        prefix.split(%r{[/\s]+})
+      end
+
+      def base_reference
+        @base_reference ||= reference.sub(%r{/(?:Amd|Cor)\s+\d+(?::\d+)?$}, "")
+      end
+    end
+  end
+end

--- a/lib/obp/access/domain_extractor.rb
+++ b/lib/obp/access/domain_extractor.rb
@@ -1,0 +1,63 @@
+module Obp
+  class Access
+    class DomainExtractor
+      Result = Struct.new(:domains, :clean_children, keyword_init: true)
+
+      DOMAIN_PATTERN = /\A\s*<([^>]+)>/
+      MAX_DOMAIN_LENGTH = 50
+
+      def self.extract(node)
+        state = { domains: [], clean_children: [], text_consumed: false }
+
+        node.children.each { |child| process_child(child, state) }
+
+        Result.new(domains: state[:domains], clean_children: state[:clean_children])
+      end
+
+      class << self
+        private
+
+        def process_child(child, state)
+          if !state[:text_consumed] && child.is_a?(Nokogiri::XML::Text)
+            process_leading_text(child, state)
+          else
+            state[:clean_children] << child
+            state[:text_consumed] = true
+          end
+        end
+
+        def process_leading_text(child, state)
+          extracted, remaining = extract_from_text(child.content)
+          state[:domains] = extracted
+          state[:text_consumed] = true
+          state[:clean_children] << remaining_node(remaining) unless remaining.strip.empty?
+        end
+
+        def extract_from_text(text)
+          domains = []
+          remaining = text.dup
+
+          while remaining =~ DOMAIN_PATTERN
+            candidate = $1.strip
+            break unless valid_domain?(candidate)
+
+            domains << candidate
+            remaining = remaining.sub(DOMAIN_PATTERN, "")
+          end
+
+          [domains, remaining]
+        end
+
+        def valid_domain?(text)
+          text.length <= MAX_DOMAIN_LENGTH &&
+            !text.include?("(") &&
+            !text.match?(/\d{2,}/)
+        end
+
+        def remaining_node(text)
+          Nokogiri::XML::Text.new(text, Nokogiri::HTML::Document.new)
+        end
+      end
+    end
+  end
+end

--- a/lib/obp/access/element_registry.rb
+++ b/lib/obp/access/element_registry.rb
@@ -1,0 +1,20 @@
+module Obp
+  class Access
+    class ElementRegistry
+      class << self
+        def register(element_class)
+          elements << element_class
+          @css_classes = nil
+        end
+
+        def elements
+          @elements ||= []
+        end
+
+        def css_classes
+          @css_classes ||= elements.filter_map(&:classes).uniq
+        end
+      end
+    end
+  end
+end

--- a/lib/obp/access/elements/array.rb
+++ b/lib/obp/access/elements/array.rb
@@ -7,56 +7,50 @@ module Obp
             %w[sts-array]
           end
 
+          private
+
           def content
             Nokogiri::XML::Builder.new do |xml|
               xml.array do
                 xml.table do
-                  render_colgroup(xml, node)
-                  render_thead(xml, node)
-                  render_tbody(xml, node)
+                  render_colgroup(xml)
+                  render_thead(xml)
+                  render_tbody(xml)
                 end
               end
             end
           end
 
-          private
-
-          def render_colgroup(xml, node)
-            nodes = node.css("colgroup col")
-            return if nodes.empty?
+          def render_colgroup(xml)
+            cols = node.css("colgroup col")
+            return if cols.empty?
 
             xml.colgroup do
-              nodes.each do |col|
-                xml.col col.attributes.slice("align", "width")
-              end
+              cols.each { |col| xml.col col.attributes.slice("align", "width") }
             end
           end
 
-          def render_thead(xml, node)
-            nodes = node.css("thead tr")
-            return if nodes.empty?
+          def render_thead(xml)
+            rows = node.css("thead tr")
+            return if rows.empty?
 
             xml.thead do
-              nodes.each do |tr|
+              rows.each do |tr|
                 xml.tr do
-                  tr.css("th").each do |th|
-                    xml.th sanitize_text(th.content)
-                  end
+                  tr.css("th").each { |th| xml.th sanitize_text(th.content) }
                 end
               end
             end
           end
 
-          def render_tbody(xml, node)
-            nodes = node.css("tbody tr")
-            return if nodes.empty?
+          def render_tbody(xml)
+            rows = node.css("tbody tr")
+            return if rows.empty?
 
             xml.tbody do
-              nodes.each do |tr|
+              rows.each do |tr|
                 xml.tr do
-                  tr.css("td").each do |td|
-                    xml.td sanitize_text(td.content)
-                  end
+                  tr.css("td").each { |td| xml.td sanitize_text(td.content) }
                 end
               end
             end
@@ -66,3 +60,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Array)

--- a/lib/obp/access/elements/base.rb
+++ b/lib/obp/access/elements/base.rb
@@ -3,7 +3,8 @@ module Obp
     class Renderer
       class Elements
         class Base
-          # Elements are rendered using the NISO STS spec here: https://www.niso-sts.org/TagLibrary/niso-sts-TL-1-2-html/index.html
+          # Elements are rendered using the NISO STS spec:
+          # https://www.niso-sts.org/TagLibrary/niso-sts-TL-1-2-html/index.html
           attr_reader :document, :metas, :node
 
           def initialize(document:, metas:, node:)
@@ -12,17 +13,33 @@ module Obp
             @node = node
           end
 
+          def self.classes
+            nil
+          end
+
           def match_node?
             node.classes == self.class.classes
           end
 
           def render(target:)
-            target = self.target if defined?(self.target) # We can force document target using Element#target method
-            target = "#{target}#{path_suffix}" if defined?(path_suffix)
-            document.at(target).send(insert_using, to_xml)
+            effective_target = insertion_target || target
+            effective_target = "#{effective_target}#{path_suffix}" if path_suffix
+            document.at(effective_target).public_send(insert_method, to_xml)
           end
 
           private
+
+          def insertion_target
+            nil
+          end
+
+          def path_suffix
+            nil
+          end
+
+          def insert_method
+            :add_child
+          end
 
           def id
             @id ||= node.attr("id").split("_").last
@@ -36,10 +53,6 @@ module Obp
             raise NotImplementedError
           end
 
-          def insert_using
-            :add_child # By default, child node is appended to the XML. Can force prepended per node
-          end
-
           def sanitize_text(text)
             text
               .gsub("<b>", "<bold>").gsub("</b>", "</bold>")
@@ -47,8 +60,7 @@ module Obp
           end
 
           def local_image_path(img)
-            key = img.attr("src")
-            metas["images"][key]
+            metas["images"][img.attr("src")]
           end
         end
       end

--- a/lib/obp/access/elements/bibliography.rb
+++ b/lib/obp/access/elements/bibliography.rb
@@ -1,25 +1,3 @@
-# HTML:
-# <tr>
-#     <td class="sts-label">
-#         <a id="iso_std_iso_34000_ed-1_v1_en_ref_1" name="iso:std:iso:34000:ed-1:v1:en:ref:1"/>
-#         <span class="sts-label">[1]</span>
-#     </td>
-#     <td>
-#         <a class="sts-std-ref" href="#iso:std:iso:8601:-1:ed-1:en">ISO 8601-1:2019</a>
-#         ,
-#         <span class="sts-std-title">
-#           Date and time — Representations for information interchange — Part 1: Basic rules
-#         </span>
-#     </td>
-# </tr>
-# STS:
-# <ref content-type="standard" id="biblref_1">
-#   <std std-id="iso:std:iso:8601:-1">
-#     <std-ref>ISO 8601-1:2019</std-ref>
-#     ,
-#     <title>Date and time — Representations for information interchange — Part 1: Basic rules</title>
-#   </std>
-# </ref>
 module Obp
   class Access
     class Renderer
@@ -29,16 +7,17 @@ module Obp
             %w[sts-section sts-ref-list]
           end
 
-          def target
+          private
+
+          def insertion_target
             "back"
           end
 
           def content
             Nokogiri::XML::Builder.new do |xml|
-              xml.send(:"ref-list", "content-type": "bibl", id: "sec_bibl") do
+              xml.public_send(:"ref-list", "content-type": "bibl", id: "sec_bibl") do
                 node.css("tr td:last-child").each_with_index do |children, index|
-                  xml.ref("content-type": "standard",
-                          id: "biblref_#{index + 1}") do
+                  xml.ref("content-type": "standard", id: "biblref_#{index + 1}") do
                     render_ref(xml, children)
                   end
                 end
@@ -46,23 +25,22 @@ module Obp
             end
           end
 
-          private
-
           def render_ref(xml, children) # rubocop:disable Metrics/AbcSize
-            attrs = {}
             href = children.at_css("a.sts-std-ref")
             title = children.at_css("span.sts-std-title")
+
+            attrs = {}
             attrs["std-id"] = href.attr("href").delete("#") if href
 
             xml.std(attrs) do
               if href
-                xml.send(:"std-ref", href.content)
+                xml.public_send(:"std-ref", href.content)
                 text = children.children[2] ? children.children[1].content : children.children[0].content
-                title = children.children[2] ? children.children[2].content : children.children[1].content
+                title_text = children.children[2] ? children.children[2].content : children.children[1].content
                 xml << text
-                xml.title title
+                xml.title title_text
               elsif title
-                xml.send(:"std-ref", children.children[0].content)
+                xml.public_send(:"std-ref", children.children[0].content)
                 xml.title children.children[1].content
               else
                 xml << children.inner_html
@@ -74,3 +52,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Bibliography)

--- a/lib/obp/access/elements/copyright.rb
+++ b/lib/obp/access/elements/copyright.rb
@@ -7,13 +7,15 @@ module Obp
             %w[sts-copyright]
           end
 
-          def target
+          private
+
+          def insertion_target
             "front/std-meta/permissions"
           end
 
           def content
             Nokogiri::XML::Builder.new do |xml|
-              xml.send(:"copyright-year", node.content.scan(/\d+/).first)
+              xml.public_send(:"copyright-year", node.content.scan(/\d+/).first)
             end
           end
         end
@@ -21,3 +23,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Copyright)

--- a/lib/obp/access/elements/figure.rb
+++ b/lib/obp/access/elements/figure.rb
@@ -8,29 +8,51 @@ module Obp
           end
 
           def match_node?
-            # Figure contains only one img in the same div.sts-fig, otherwise it's a fig-group
-            super && node.css("img").one?
-          end
-
-          def content
-            Nokogiri::XML::Builder.new do |xml|
-              xml.fig do
-                render_figure(xml, node)
-              end
-            end
+            super && node.css("img").any?
           end
 
           private
 
-          def render_figure(xml, children)
-            xml.label children.at(".sts-caption-label").content
-            xml.caption do
-              xml.title children.at(".sts-caption-title").content
+          def content
+            Nokogiri::XML::Builder.new do |xml|
+              xml.fig do
+                render_caption(xml)
+                xml.graphic("xlink:href": local_image_path(node.at_css("img")))
+
+                legend_table = node.at_css("div.sts-table-wrap.fig-index")
+                render_legend(xml, legend_table) if legend_table
+              end
             end
-            xml.graphic("xlink:href": local_image_path(children.at("img")))
+          end
+
+          def render_caption(xml)
+            caption = node.at_css(".sts-caption")
+            return unless caption
+
+            label = caption.at_css(".sts-caption-label")
+            xml.label label.content if label
+            title = caption.at_css(".sts-caption-title")
+            xml.caption do
+              xml.title title.content if title
+            end
+          end
+
+          def render_legend(xml, table_node)
+            xml.public_send(:"table-wrap", "content-type": "legend") do
+              caption = table_node.at_css(".sts-caption")
+              if caption
+                xml.caption do
+                  title = caption.at_css(".sts-caption-title")
+                  xml.title title.content if title
+                end
+              end
+              xml.table { xml << table_node.at_css("table").inner_html }
+            end
           end
         end
       end
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Figure)

--- a/lib/obp/access/elements/figure_group.rb
+++ b/lib/obp/access/elements/figure_group.rb
@@ -8,25 +8,21 @@ module Obp
           end
 
           def match_node?
-            # Figure group contains many img in the same div.sts-fig, otherwise it's a fig
             super && node.css("img").count > 1
-          end
-
-          def content
-            Nokogiri::XML::Builder.new do |xml|
-              xml.send(:"fig-group") do
-                render_caption(xml, node)
-                node.css("img").each do |children|
-                  render_figure(xml, children)
-                end
-              end
-            end
           end
 
           private
 
+          def content
+            Nokogiri::XML::Builder.new do |xml|
+              xml.public_send(:"fig-group") do
+                render_caption(xml, node)
+                node.css("img").each { |img| render_figure(xml, img) }
+              end
+            end
+          end
+
           def render_caption(xml, children)
-            # children.at will return the first caption, which is used for fig-group caption
             xml.label children.at(".sts-caption-label").content
             xml.caption do
               xml.title children.at(".sts-caption-title").content
@@ -35,7 +31,7 @@ module Obp
 
           def render_figure(xml, img)
             xml.fig do
-              div = img.previous # Find the caption related to this img
+              div = img.previous
               xml.label div.at(".sts-caption-label").content
               xml.caption do
                 xml.title div.at(".sts-caption-title").content
@@ -48,3 +44,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::FigureGroup)

--- a/lib/obp/access/elements/index.rb
+++ b/lib/obp/access/elements/index.rb
@@ -1,0 +1,113 @@
+module Obp
+  class Access
+    class Renderer
+      class Elements
+        class Index < Base
+          def self.classes
+            %w[sts-section]
+          end
+
+          def match_node?
+            super && index_section?
+          end
+
+          private
+
+          def index_section?
+            node_id = node.attr("id").to_s
+            node_id.include?("sec_index") || index_title?
+          end
+
+          def index_title?
+            title = node.at_css("h1.sts-sec-title")
+            title&.text&.match?(/index|Index|verzeichnis/i)
+          end
+
+          def insertion_target
+            "body"
+          end
+
+          def content
+            Nokogiri::XML::Builder.new do |xml|
+              xml.sec(id: "sec_index") do
+                xml.title index_title_text
+                xml.index do
+                  render_index_divs(xml)
+                end
+              end
+            end
+          end
+
+          def render_index_divs(xml)
+            grouped_entries.each do |letter, entries|
+              xml.public_send(:"index-div") do
+                xml.title letter
+                entries.each { |entry| render_index_entry(xml, entry) }
+              end
+            end
+          end
+
+          def render_index_entry(xml, entry)
+            xml.public_send(:"index-entry") do
+              xml.term entry[:term]
+              entry[:refs].each do |ref|
+                xml.xref("ref-type": "sec", rid: "sec_#{ref[:rid]}") { xml << ref[:text] }
+              end
+            end
+          end
+
+          def index_title_text
+            node.at_css("h1.sts-sec-title")&.text || "Index"
+          end
+
+          def grouped_entries
+            groups = {}
+            current_letter = nil
+
+            node.css("div.sts-p").each do |para|
+              letter = letter_heading(para)
+              if letter
+                current_letter = letter
+                groups[current_letter] ||= []
+              elsif current_letter && index_entry?(para)
+                groups[current_letter] << parse_entry(para)
+              end
+            end
+
+            groups
+          end
+
+          def letter_heading(para)
+            return nil unless para.inner_html.match?(/\A<b>[A-Z0-9À-Ü]<\/b>\z/)
+
+            para.at_css("b")&.text
+          end
+
+          def index_entry?(para)
+            !para.at_css("a.sts-xref").nil?
+          end
+
+          def parse_entry(para)
+            term_node = para.at_css("a.sts-xref")
+            { term: entry_term_text(term_node), refs: entry_refs(para) }
+          end
+
+          def entry_term_text(term_node)
+            preceding = term_node.previous
+            return "" unless preceding.is_a?(Nokogiri::XML::Text)
+
+            preceding.text.strip.gsub(/[[:space:]]+/, " ").strip
+          end
+
+          def entry_refs(para)
+            para.css("a.sts-xref").map do |xref|
+              { rid: xref.attr("href").split(":").last, text: xref.text.strip }
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Index)

--- a/lib/obp/access/elements/introduction.rb
+++ b/lib/obp/access/elements/introduction.rb
@@ -8,11 +8,12 @@ module Obp
           end
 
           def match_node?
-            # Section foreword & introduction ids finishes with "foreword" & "intro"
             super && %w[foreword intro].include?(id)
           end
 
-          def target
+          private
+
+          def insertion_target
             "front"
           end
 
@@ -26,3 +27,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Introduction)

--- a/lib/obp/access/elements/list.rb
+++ b/lib/obp/access/elements/list.rb
@@ -3,26 +3,50 @@ module Obp
     class Renderer
       class Elements
         class List < Base
+          include InlineRenderer
+
           def self.classes
             %w[list]
           end
 
+          private
+
           def content
             Nokogiri::XML::Builder.new do |xml|
-              # FIXME: How to define "list-type" attribute ("alpha-lower" or "dash")?
               xml.list("list-type": "dash") do
-                # Take only first level li children
-                node.xpath("./ul/li").map do |li|
-                  xml.send(:"list-item") do
-                    label = li.at_css("span.sts-label")
-                    p = label.next
-
-                    # FIXME: Re-use Elements classes for labels & paragraphs
-                    xml.label label.content
-                    xml.p p.content
+                node.xpath("./ul/li").each do |li|
+                  xml.public_send(:"list-item") do
+                    render_li(xml, li)
                   end
                 end
               end
+            end
+          end
+
+          def render_li(xml, item)
+            render_li_label(xml, item)
+            render_li_paragraph(xml, item)
+            render_nested_list(xml, item)
+          end
+
+          def render_li_label(xml, item)
+            label = item.at_css("span.sts-label")
+            xml.label label.text if label
+          end
+
+          def render_li_paragraph(xml, item)
+            p_node = item.at_css(".sts-p")
+            return unless p_node
+
+            xml.p { p_node.children.each { |c| render_inline(xml, c) } }
+          end
+
+          def render_nested_list(xml, item)
+            nested = item.at_css(".list")
+            return unless nested
+
+            nested.xpath("./ul/li").each do |nested_item|
+              xml.public_send(:"list-item") { render_li(xml, nested_item) }
             end
           end
         end
@@ -30,3 +54,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::List)

--- a/lib/obp/access/elements/non_normative_note.rb
+++ b/lib/obp/access/elements/non_normative_note.rb
@@ -1,0 +1,47 @@
+module Obp
+  class Access
+    class Renderer
+      class Elements
+        class NonNormativeNote < Base
+          include InlineRenderer
+
+          def self.classes
+            %w[sts-non-normative-note]
+          end
+
+          private
+
+          def content
+            Nokogiri::XML::Builder.new do |xml|
+              xml.public_send(:"non-normative-note") do
+                label_node = node.at_css(".sts-non-normative-note-label")
+                xml.label label_node.text if label_node
+
+                p_node = node.at_css("p")
+                if p_node
+                  xml.p do
+                    p_node.children.each { |child| render_inline(xml, child) }
+                  end
+                end
+              end
+            end
+          end
+
+          def inline_type(node)
+            if node.is_a?(Nokogiri::XML::Text)
+              :text
+            elsif node.is_a?(Nokogiri::XML::Element)
+              if node.classes == ["sts-non-normative-note-label"]
+                :label
+              else
+                super
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::NonNormativeNote)

--- a/lib/obp/access/elements/paragraph.rb
+++ b/lib/obp/access/elements/paragraph.rb
@@ -3,18 +3,23 @@ module Obp
     class Renderer
       class Elements
         class Paragraph < Base
+          include InlineRenderer
+
           def self.classes
             %w[sts-p]
           end
 
           def match_node?
-            # Paragraph in a list are rendered within the list element
             super && node.parent.name != "li"
           end
 
+          private
+
           def content
             Nokogiri::XML::Builder.new do |xml|
-              xml.p sanitize_text(node.inner_html)
+              xml.p do
+                node.children.each { |child| render_inline(xml, child) }
+              end
             end
           end
         end
@@ -22,3 +27,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Paragraph)

--- a/lib/obp/access/elements/root.rb
+++ b/lib/obp/access/elements/root.rb
@@ -3,6 +3,8 @@ module Obp
     class Renderer
       class Elements
         class Root
+          TITLE_PARTS = %w[intro main compl].freeze
+
           attr_reader :urn, :metas
 
           def initialize(urn:, metas:)
@@ -11,24 +13,23 @@ module Obp
           end
 
           def content # rubocop:disable Metrics/AbcSize
-            # Force namespace_inheritance to stop children inherit their parent’s namespace
             Nokogiri::XML::Builder.new(namespace_inheritance: false,
                                        encoding: "UTF-8") do |xml|
               xml.standard("xmlns:xlink": "http://www.w3.org/1999/xlink",
                            "xmlns:mml": "http://www.w3.org/1998/Math/MathML",
-                           "xmlns:tbx": urn) do
+                           "xmlns:tbx": "urn:iso:std:iso:30042:ed-2") do
                 xml.front do
-                  xml.send(:"std-meta") do
+                  xml.public_send(:"std-meta") do
                     xml.permissions do
-                      xml.send(:"copyright-statement", "All rights reserved")
-                      xml.send(:"copyright-holder", holder)
+                      xml.public_send(:"copyright-statement", "All rights reserved")
+                      xml.public_send(:"copyright-holder", holder)
                     end
                     render_titles(xml)
-                    xml.send(:"proj-id", ref_undated)
-                    xml.send(:"content-language", metas["language"])
-                    xml.send(:"std-ref", ref_dated, type: "dated")
-                    xml.send(:"std-ref", ref_undated, type: "undated")
-                    xml.send(:"doc-ref", ref)
+                    xml.public_send(:"proj-id", ref_undated)
+                    xml.public_send(:"content-language", metas["language"])
+                    xml.public_send(:"std-ref", ref_dated, type: "dated")
+                    xml.public_send(:"std-ref", ref_undated, type: "undated")
+                    xml.public_send(:"doc-ref", ref)
                   end
                 end
                 xml.body
@@ -61,11 +62,12 @@ module Obp
 
           def render_titles(xml)
             metas["titles"].each do |language, title|
-              xml.send(:"title-wrap", "xml:lang": language) do
+              next unless title
+
+              xml.public_send(:"title-wrap", "xml:lang": language) do
                 split = title.split("—")
-                elements = %w[intro main compl]
-                elements.each_with_index do |e, i|
-                  xml.send(e, split[i].strip) if split[i]
+                TITLE_PARTS.each_with_index do |e, i|
+                  xml.public_send(e, split[i].strip) if split[i]
                 end
                 xml.full title
               end

--- a/lib/obp/access/elements/section.rb
+++ b/lib/obp/access/elements/section.rb
@@ -8,11 +8,12 @@ module Obp
           end
 
           def match_node?
-            # Section ids finish with an integer or decimal
             super && id =~ /\A\d+(\.\d+)*\z/
           end
 
-          def target
+          private
+
+          def insertion_target
             "body"
           end
 
@@ -28,3 +29,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Section)

--- a/lib/obp/access/elements/table_wrap.rb
+++ b/lib/obp/access/elements/table_wrap.rb
@@ -7,13 +7,23 @@ module Obp
             %w[sts-table-wrap fig-index]
           end
 
+          def match_node?
+            super && !inside_figure?
+          end
+
+          private
+
+          def inside_figure?
+            node.ancestors.any? { |a| a.classes == ["sts-fig"] }
+          end
+
           def content
             Nokogiri::XML::Builder.new do |xml|
-              xml.send(:"table-wrap") do
-                xml.label label if label
-                if caption
+              xml.public_send(:"table-wrap") do
+                xml.label caption_label if caption_label
+                if caption_text
                   xml.caption do
-                    xml.title caption
+                    xml.title caption_text
                   end
                 end
                 xml.table { xml << node.at_css("table").inner_html }
@@ -21,17 +31,17 @@ module Obp
             end
           end
 
-          private
-
-          def label
-            @label ||= node.at_css(".sts-caption-label")&.content
+          def caption_label
+            @caption_label ||= node.at_css(".sts-caption-label")&.content
           end
 
-          def caption
-            @caption ||= node.at_css(".sts-caption")&.content
+          def caption_text
+            @caption_text ||= node.at_css(".sts-caption")&.content
           end
         end
       end
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::TableWrap)

--- a/lib/obp/access/elements/terminology.rb
+++ b/lib/obp/access/elements/terminology.rb
@@ -7,12 +7,14 @@ module Obp
             %w[sts-section sts-tbx-sec]
           end
 
+          private
+
           def content
             Nokogiri::XML::Builder.new do |xml|
-              xml.send(:"term-sec", id: "sec_#{id}") do
+              xml.public_send(:"term-sec", id: "sec_#{id}") do
                 xml.label id
-                xml.send(:"tbx:termEntry", id: "term_#{id}") do
-                  xml.send(:"tbx:langSet", "xml:lang": metas["language"])
+                xml.public_send(:"tbx:termEntry", id: "term_#{id}") do
+                  xml.public_send(:"tbx:langSet", "xml:lang": metas["language"])
                 end
               end
             end
@@ -22,3 +24,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Terminology)

--- a/lib/obp/access/elements/terminology/base.rb
+++ b/lib/obp/access/elements/terminology/base.rb
@@ -4,37 +4,20 @@ module Obp
       class Elements
         class Terminology
           class Base < Elements::Base
-            def self.classes; end
+            include InlineRenderer
+
+            def self.classes
+              nil
+            end
+
+            private
 
             def path_suffix
               "/tbx:termEntry/tbx:langSet"
             end
 
-            private
-
-            def render_entailed_term(xml, children)
-              if children.classes == ["sts-tbx-entailedTerm"]
-                target = children.at_css("a").attr("href").split(":").last
-                xml.send(:"tbx:entailedTerm", target: "term_#{target}") do
-                  xml << sanitize_text(children.text)
-                end
-              elsif children.is_a?(Nokogiri::XML::Text)
-                xml.text(children.content)
-              end
-            end
-
-            def tbx_category(node)
-              content = node.inner_html
-              type = "noun"
-
-              if content.end_with?("<b>verb</b>")
-                content = node.inner_html.gsub("<b>verb</b>", "").gsub(
-                  "<b>,</b>", ""
-                )
-                type = "verb"
-              end
-
-              [sanitize_text(content), type]
+            def bold_term?(node)
+              node.inner_html.start_with?("<b>") || node.inner_html.include?("<b>")
             end
           end
         end

--- a/lib/obp/access/elements/terminology/definition.rb
+++ b/lib/obp/access/elements/terminology/definition.rb
@@ -8,18 +8,31 @@ module Obp
               %w[sts-tbx-def]
             end
 
-            def insert_using
-              :prepend_child # In this XML, order matters. This node needs to appear before tbx:tig
+            private
+
+            def insert_method
+              :prepend_child
             end
 
             def content
-              Nokogiri::XML::Builder.new do |xml|
-                xml.send(:"tbx:definition") do
-                  node.children.each do |children|
-                    render_entailed_term(xml, children)
-                  end
+              extracted = DomainExtractor.extract(node)
+              @fragment = Nokogiri::XML::DocumentFragment.new(document)
+
+              Nokogiri::XML::Builder.with(@fragment) do |xml|
+                extracted.domains.each do |domain|
+                  xml.public_send(:"tbx:subjectField") { xml << domain }
+                end
+                xml.public_send(:"tbx:definition") do
+                  extracted.clean_children.each { |child| render_inline(xml, child) }
                 end
               end
+
+              @fragment
+            end
+
+            def to_xml
+              content
+              @fragment.to_xml
             end
           end
         end
@@ -27,3 +40,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Terminology::Definition)

--- a/lib/obp/access/elements/terminology/example.rb
+++ b/lib/obp/access/elements/terminology/example.rb
@@ -8,12 +8,12 @@ module Obp
               %w[sts-tbx-example]
             end
 
+            private
+
             def content
               Nokogiri::XML::Builder.new do |xml|
-                xml.send(:"tbx:example") do
-                  node.css(".sts-tbx-example-content").children.each do |children|
-                    render_entailed_term(xml, children)
-                  end
+                xml.public_send(:"tbx:example") do
+                  node.css(".sts-tbx-example-content").children.each { |children| render_inline(xml, children) }
                 end
               end
             end
@@ -23,3 +23,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Terminology::Example)

--- a/lib/obp/access/elements/terminology/note.rb
+++ b/lib/obp/access/elements/terminology/note.rb
@@ -8,13 +8,12 @@ module Obp
               %w[sts-tbx-note]
             end
 
+            private
+
             def content
               Nokogiri::XML::Builder.new do |xml|
-                xml.send(:"tbx:note") do
-                  # NOTE: Can't guess <std><std-ref>
-                  node.children.each do |children|
-                    render_entailed_term(xml, children)
-                  end
+                xml.public_send(:"tbx:note") do
+                  node.children.each { |children| render_inline(xml, children) }
                 end
               end
             end
@@ -24,3 +23,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Terminology::Note)

--- a/lib/obp/access/elements/terminology/source.rb
+++ b/lib/obp/access/elements/terminology/source.rb
@@ -1,22 +1,3 @@
-# HTML:
-# <div class="sts-tbx-source">
-#     [SOURCE:26th meeting of the CGPM (2018)
-#     <sup>[</sup>
-#     <a class="sts-xref" href="#iso:std:iso:34000:ed-1:v1:en:ref:10" title="
-#         [10] CGPM22 Conférence Générale des Poids et Mesures / General Conference on Weights and Measures. Meeting 26,
-#         General Conference on Weights and Measures. 26th meeting of the CGPM. Paris: Bureau International des Poids et
-#         Mesures. November 16, 2018. Available from: https://www.bipm.org/en/committees/cg/cgpm/26-2018.">
-#         <sup>10</sup>
-#     </a>
-#     <sup>]</sup>
-#     , Resolution 2, modified – Note 1 to entry has been expanded upon for clarity.]
-# </div>
-# STS:
-# <tbx:source>
-#   26th meeting of the CGPM (2018)
-#   <sup>[</sup><xref ref-type="bibr" rid="ref_10"><sup>10</sup></xref><sup>]</sup>,
-#   Resolution 2, modified – Note 1 to entry has been expanded upon for clarity.
-# </tbx:source>
 module Obp
   class Access
     class Renderer
@@ -27,9 +8,11 @@ module Obp
               %w[sts-tbx-source]
             end
 
+            private
+
             def content
               Nokogiri::XML::Builder.new do |xml|
-                xml.send(:"tbx:source") do
+                xml.public_send(:"tbx:source") do
                   node.children.each do |child|
                     if child.classes == ["sts-xref"]
                       render_ref(xml, child)
@@ -40,8 +23,6 @@ module Obp
                 end
               end
             end
-
-            private
 
             def render_ref(xml, child)
               rid = child.attr("href").split(":").last
@@ -60,3 +41,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Terminology::Source)

--- a/lib/obp/access/elements/terminology/tig.rb
+++ b/lib/obp/access/elements/terminology/tig.rb
@@ -8,25 +8,45 @@ module Obp
               %w[sts-tbx-term]
             end
 
+            private
+
             def id
-              # The ID is attached to the section, not this div
               node.parent.at_css("div.sts-tbx-label").text.strip
             end
 
             def index
-              node.path.match(/\[(\d+)\](?=\z)/)[1].to_i - 1 # Extract index from xpath
+              node.path.match(/\[(\d+)\](?=\z)/)[1].to_i - 1
+            end
+
+            def normative_authorization
+              bold_term?(node) ? "admittedTerm" : "preferredTerm"
             end
 
             def content
               Nokogiri::XML::Builder.new do |xml|
-                xml.send(:"tbx:tig", id: "term_#{id}-#{index}") do
-                  term, part_of_speech = tbx_category(node)
-                  # Force xml tags generation rather than html escaping
-                  xml.send(:"tbx:term") do
-                    xml << term
-                  end
-                  xml.send(:"tbx:partOfSpeech", value: part_of_speech)
+                xml.public_send(:"tbx:tig", id: "term_#{id}-#{index}") do
+                  render_tig_content(xml)
                 end
+              end
+            end
+
+            def render_tig_content(xml)
+              result = GrammarParser.parse(parsed_html)
+              xml.public_send(:"tbx:term") { xml << result.term }
+              xml.public_send(:"tbx:partOfSpeech", value: result.pos)
+              render_genders(xml, result.genders)
+              xml.public_send(:"tbx:normativeAuthorization", value: normative_authorization)
+            end
+
+            def parsed_html
+              node.inner_html
+            end
+
+            def render_genders(xml, genders)
+              return unless genders.any?
+
+              genders.each do |gender|
+                xml.public_send(:"tbx:gram", value: gender, type: "gender")
               end
             end
           end
@@ -35,3 +55,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Terminology::Tig)

--- a/lib/obp/access/elements/terminology/tig_admitted.rb
+++ b/lib/obp/access/elements/terminology/tig_admitted.rb
@@ -8,18 +8,10 @@ module Obp
               %w[sts-tbx-term admittedTerm]
             end
 
-            def content
-              Nokogiri::XML::Builder.new do |xml|
-                xml.send(:"tbx:tig", id: "term_#{id}-#{index}") do
-                  term, part_of_speech = tbx_category(node)
-                  # Force xml tags generation rather than html escaping
-                  xml.send(:"tbx:term") do
-                    xml << term
-                  end
-                  xml.send(:"tbx:partOfSpeech", value: part_of_speech)
-                  xml.send(:"tbx:normativeAuthorization", value: "admittedTerm")
-                end
-              end
+            private
+
+            def normative_authorization
+              "admittedTerm"
             end
           end
         end
@@ -27,3 +19,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Terminology::TigAdmitted)

--- a/lib/obp/access/elements/terminology/tig_deprecated.rb
+++ b/lib/obp/access/elements/terminology/tig_deprecated.rb
@@ -1,0 +1,39 @@
+module Obp
+  class Access
+    class Renderer
+      class Elements
+        class Terminology
+          class TigDeprecated < Tig
+            def self.classes
+              %w[sts-tbx-term deprecatedTerm]
+            end
+
+            private
+
+            def normative_authorization
+              "deprecatedTerm"
+            end
+
+            def content
+              Nokogiri::XML::Builder.new do |xml|
+                xml.public_send(:"tbx:tig", id: "term_#{id}-#{index}") do
+                  render_tig_content(xml)
+                end
+              end
+            end
+
+            def parsed_html
+              strip_deprecation_label(node.inner_html)
+            end
+
+            def strip_deprecation_label(html)
+              html.gsub(%r{<span class="sts-tbx-term-depr-label">.*?</span>}, "")
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Terminology::TigDeprecated)

--- a/lib/obp/access/elements/terminology/tig_preferred.rb
+++ b/lib/obp/access/elements/terminology/tig_preferred.rb
@@ -8,19 +8,10 @@ module Obp
               %w[sts-tbx-term preferredTerm]
             end
 
-            def content
-              Nokogiri::XML::Builder.new do |xml|
-                xml.send(:"tbx:tig", id: "term_#{id}-#{index}") do
-                  term, part_of_speech = tbx_category(node)
-                  # Force xml tags generation rather than html escaping
-                  xml.send(:"tbx:term") do
-                    xml << term
-                  end
-                  xml.send(:"tbx:partOfSpeech", value: part_of_speech)
-                  xml.send(:"tbx:normativeAuthorization",
-                           value: "preferredTerm")
-                end
-              end
+            private
+
+            def normative_authorization
+              "preferredTerm"
             end
           end
         end
@@ -28,3 +19,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Terminology::TigPreferred)

--- a/lib/obp/access/elements/title.rb
+++ b/lib/obp/access/elements/title.rb
@@ -7,8 +7,10 @@ module Obp
             %w[sts-sec-title]
           end
 
-          def insert_using
-            :prepend_child # In this XML, order matters. This node needs to appear at the top of the XML section
+          private
+
+          def insert_method
+            :prepend_child
           end
 
           def content
@@ -21,3 +23,5 @@ module Obp
     end
   end
 end
+
+Obp::Access::ElementRegistry.register(Obp::Access::Renderer::Elements::Title)

--- a/lib/obp/access/fetcher.rb
+++ b/lib/obp/access/fetcher.rb
@@ -1,0 +1,63 @@
+module Obp
+  class Access
+    class Fetcher
+      USER_AGENT_PROFILES = [
+        {
+          user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " \
+                      "AppleWebKit/537.36 (KHTML, like Gecko) " \
+                      "Chrome/131.0.0.0 Safari/537.36",
+          platform: '"macOS"',
+          chrome_version: "131",
+        },
+        {
+          user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " \
+                      "AppleWebKit/537.36 (KHTML, like Gecko) " \
+                      "Chrome/130.0.0.0 Safari/537.36",
+          platform: '"Windows"',
+          chrome_version: "130",
+        },
+        {
+          user_agent: "Mozilla/5.0 (X11; Linux x86_64) " \
+                      "AppleWebKit/537.36 (KHTML, like Gecko) " \
+                      "Chrome/131.0.0.0 Safari/537.36",
+          platform: '"Linux"',
+          chrome_version: "131",
+        },
+      ].freeze
+
+      def initialize(urn:)
+        @urn = urn
+      end
+
+      def fetch_state
+        response = post_ui_request
+        parse_state(response)
+      end
+
+      private
+
+      def post_ui_request
+        uri = URI(API_URL)
+        request = Net::HTTP::Post.new(uri)
+        profile = USER_AGENT_PROFILES.sample
+        request["User-Agent"] = profile[:user_agent]
+        request["Accept"] = "application/json"
+        request.set_form_data(
+          "v-browserDetails" => 1,
+          "theme" => "iso-red",
+          "v-loc" => "#{API_URL}##{@urn}",
+        )
+
+        Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+      end
+
+      def parse_state(response)
+        json = JSON.parse(response.body)
+        state_json = JSON.parse(json["uidl"])
+        state_json["state"].values
+      end
+    end
+  end
+end

--- a/lib/obp/access/grammar_parser.rb
+++ b/lib/obp/access/grammar_parser.rb
@@ -1,0 +1,135 @@
+module Obp
+  class Access
+    class GrammarParser
+      Result = Struct.new(:term, :pos, :genders, keyword_init: true)
+
+      POS_MAP = {
+        "adj." => "adjective",
+        "Adj." => "adjective",
+        "verb" => "verb",
+      }.freeze
+
+      GENDER_VALUES = %w[m f n].freeze
+
+      BOLD_PATTERNS = [
+        [->(t) { POS_MAP.key?(t) }, :handle_pos_marker],
+        [->(t) { GENDER_VALUES.include?(t) }, :handle_gender_marker],
+        [->(t) { t.match?(/\A[mfn],\z/) }, :handle_gender_with_comma],
+        [->(t) { t.match?(/\A[mfn][,\s]+[mfn]([,\s]+[mfn])*\z/) }, :handle_multi_gender],
+        [->(t) { t == "," }, :handle_comma],
+        [->(t) { t == "〈" },                     :handle_enter_bracket],
+        [->(t) { t == "〉" },                     :handle_exit_bracket],
+        [->(t) { t.match?(/\A[mfn]\s+/) },       :handle_gender_qualifier],
+        [->(t) { t.match?(/,.+[mfn]\z/) },       :handle_term_with_gender],
+      ].freeze
+
+      def self.parse(inner_html)
+        state = { pos: "noun", genders: [], term_parts: [], in_bracket: false }
+        segments = parse_segments(inner_html)
+
+        segments.each do |seg|
+          handler = find_handler(seg, state[:in_bracket])
+          handler.call(seg[:text], state)
+        end
+
+        Result.new(term: clean_term(state[:term_parts]), pos: state[:pos], genders: state[:genders].uniq)
+      end
+
+      class << self
+        private
+
+        def find_handler(seg, in_bracket)
+          if seg[:bold]
+            bold_handler(seg[:text].strip, in_bracket)
+          elsif in_bracket
+            method(:handle_skip)
+          else
+            method(:handle_text)
+          end
+        end
+
+        def bold_handler(text, in_bracket)
+          _pattern, handler = BOLD_PATTERNS.find { |pred, _| pred.call(text) }
+          return method(handler) if handler
+
+          in_bracket ? method(:handle_skip) : method(:handle_term_text)
+        end
+
+        def handle_pos_marker(text, state)
+          state[:pos] = POS_MAP[text.strip]
+        end
+
+        def handle_gender_marker(text, state)
+          state[:genders] << text.strip
+        end
+
+        def handle_gender_with_comma(text, state)
+          state[:genders] << text.strip[0]
+        end
+
+        def handle_multi_gender(text, state)
+          text.strip.scan(/[mfn]/).each { |g| state[:genders] << g }
+        end
+
+        def handle_enter_bracket(_text, state)
+          state[:in_bracket] = true
+        end
+
+        def handle_exit_bracket(_text, state)
+          state[:in_bracket] = false
+        end
+
+        def handle_gender_qualifier(text, state)
+          state[:genders] << text.strip[0]
+        end
+
+        def handle_term_with_gender(text, state)
+          stripped = text.strip
+          if stripped =~ /\A(.+),\s*([mfn])\z/
+            state[:term_parts] << $1.strip
+            state[:genders] << $2
+          else
+            state[:term_parts] << stripped
+          end
+        end
+
+        def handle_comma(_text, _state); end
+
+        def handle_term_text(text, state)
+          state[:term_parts] << text
+        end
+
+        def handle_text(text, state)
+          state[:term_parts] << text
+        end
+
+        def handle_skip(_text, _state); end
+
+        def parse_segments(html)
+          segments = []
+          remaining = html.dup
+
+          while remaining.length.positive?
+            match = remaining.match(/\A(.*?)(<b>(.*?)<\/b>)(.*)/m)
+            if match
+              segments << { text: match[1], bold: false } if match[1].length.positive?
+              segments << { text: match[3], bold: true }
+              remaining = match[4]
+            else
+              segments << { text: remaining, bold: false }
+              break
+            end
+          end
+
+          segments
+        end
+
+        def clean_term(parts)
+          combined = parts.join
+          combined = combined.gsub(/,\s*\z/, "")
+          combined.gsub(/\s+/, " ").strip
+        end
+      end
+    end
+  end
+end

--- a/lib/obp/access/imager.rb
+++ b/lib/obp/access/imager.rb
@@ -10,7 +10,6 @@ module Obp
 
       def images
         doc = Nokogiri::HTML(html)
-        # For now, only images in <fig> are supported
         images = doc.search("div.sts-fig > img").to_h do |img|
           key = img.attr("src")
           path = File.join(imgdir, key.split("/").last)
@@ -26,16 +25,14 @@ module Obp
         @imgdir ||= FileUtils.mkdir(File.join(directory, "images")).first
       end
 
-      # Parallelize images fetching to speed up process
       def download_images(images)
         Parallel.each(images) { |key, path| download_image(key, path) }
       end
 
       def download_image(key, path)
         url = "#{BASE_URL}#{key}"
-
-        image_blob = Net::HTTP.get_response(URI(url)).body
-        File.write(path, image_blob, mode: "wb")
+        blob = Net::HTTP.get_response(URI(url)).body
+        File.write(path, blob, mode: "wb")
       end
     end
   end

--- a/lib/obp/access/inline_renderer.rb
+++ b/lib/obp/access/inline_renderer.rb
@@ -1,0 +1,95 @@
+module Obp
+  class Access
+    module InlineRenderer
+      CLASS_TYPES = {
+        %w[sts-tbx-entailedTerm] => :entailed_term,
+        %w[sts-xref] => :xref,
+        %w[sts-std-ref] => :std_ref,
+        %w[sts-label] => :label,
+      }.freeze
+
+      def render_inline(xml, node)
+        return xml.text(node.content) if node.is_a?(Nokogiri::XML::Text)
+
+        render_node_by_type(xml, node, inline_type(node))
+      end
+
+      CONTAINER_TYPES = { italic: :italic, bold: :bold }.freeze
+
+      def render_node_by_type(xml, node, type)
+        if CONTAINER_TYPES.key?(type)
+          render_container(xml, node, CONTAINER_TYPES[type])
+        elsif type == :label
+          nil
+        elsif type == :element
+          render_children(xml, node)
+        else
+          render_named_type(xml, node, type)
+        end
+      end
+
+      def render_named_type(xml, node, type)
+        case type
+        when :entailed_term then render_entailed_term(xml, node)
+        when :xref then render_xref(xml, node)
+        when :std_ref then render_std_ref(xml, node)
+        when :ext_link then render_ext_link(xml, node)
+        end
+      end
+
+      def render_container(xml, node, tag)
+        xml.public_send(tag) { node.children.each { |c| render_inline(xml, c) } }
+      end
+
+      def render_children(xml, node)
+        node.children.each { |c| render_inline(xml, c) }
+      end
+
+      def inline_type(node)
+        return :text if node.is_a?(Nokogiri::XML::Text)
+
+        CLASS_TYPES.fetch(node.classes) do
+          case node.name
+          when "i" then :italic
+          when "a" then :ext_link
+          when "b" then :bold
+          else :element
+          end
+        end
+      end
+
+      def xref_ref_type(text)
+        case text
+        when /\AFigure/ then "fig"
+        when /\ATable/  then "table"
+        when /\ANote/   then "fn"
+        else "sec"
+        end
+      end
+
+      private
+
+      def render_entailed_term(xml, node)
+        target = node.at_css("a").attr("href").split(":").last
+        xml.public_send(:"tbx:entailedTerm", target: "term_#{target}") do
+          xml << node.text.strip
+        end
+      end
+
+      def render_xref(xml, node)
+        rid = node.attr("href").split(":").last
+        ref_type = xref_ref_type(node.text)
+        xml.xref("ref-type": ref_type, rid: "#{ref_type}_#{rid}") { xml << node.text.strip }
+      end
+
+      def render_std_ref(xml, node)
+        rid = node.attr("href").split(":").last
+        xml.xref("ref-type": "bibr", rid: "ref_#{rid}") { xml << node.text.strip }
+      end
+
+      def render_ext_link(xml, node)
+        xml.public_send(:"ext-link", "xlink:href" => node.attr("href")) { xml << node.text.strip }
+      end
+    end
+  end
+end

--- a/lib/obp/access/multilingual_merger.rb
+++ b/lib/obp/access/multilingual_merger.rb
@@ -1,0 +1,165 @@
+module Obp
+  class Access
+    class MultilingualMerger
+      include InlineRenderer
+
+      CHILD_TYPE_RENDERERS = {
+        %w[sts-tbx-def] => :render_definition,
+        %w[sts-tbx-note] => :render_note,
+        %w[sts-tbx-example] => :render_example,
+        %w[sts-tbx-source] => :render_source,
+      }.freeze
+
+      def initialize(primary_document, additional_sources, _metas)
+        @document = primary_document
+        @additional_sources = additional_sources
+      end
+
+      def merge
+        @additional_sources.each do |language, html|
+          merge_language(language, html)
+        end
+        @document
+      end
+
+      private
+
+      def merge_language(language, html)
+        doc = Nokogiri::HTML(html.gsub(/[[:space:]]/, " "))
+        standard = doc.at_css("div.sts-standard")
+        return unless standard
+
+        term_sections(standard).each do |section|
+          label = section_label(section)
+          next unless label
+
+          term_entry = find_term_entry(label)
+          next unless term_entry
+
+          langset = build_langset(section, language)
+          term_entry.add_child(langset)
+        end
+      end
+
+      def find_term_entry(label)
+        @document.at_xpath("//*[@id='term_#{label}' and local-name()='termEntry']")
+      end
+
+      def term_sections(standard)
+        standard.css("div.sts-section.sts-tbx-sec")
+      end
+
+      def section_label(section)
+        section.at_css("div.sts-tbx-label")&.text&.strip
+      end
+
+      def build_langset(section, language)
+        builder = Nokogiri::XML::Builder.new do |xml|
+          xml.public_send(:"tbx:langSet", "xml:lang": language) do
+            section.children.each do |child|
+              render_section_child(xml, child)
+            end
+          end
+        end
+        builder.doc.root
+      end
+
+      def render_section_child(xml, child)
+        return unless child.is_a?(Nokogiri::XML::Element)
+
+        classes = child.classes
+        if classes.include?("sts-tbx-term")
+          render_term_type(xml, child, classes)
+        else
+          render_typed_child(xml, child, classes)
+        end
+      end
+
+      def render_typed_child(xml, child, classes)
+        renderer = CHILD_TYPE_RENDERERS[classes]
+        return unless renderer
+
+        case renderer
+        when :render_definition then render_definition(xml, child)
+        when :render_note then render_note(xml, child)
+        when :render_example then render_example(xml, child)
+        when :render_source then render_source(xml, child)
+        end
+      end
+
+      def render_term_type(xml, child, classes)
+        if classes.include?("deprecatedTerm")
+          render_deprecated_tig(xml, child)
+        else
+          render_tig(xml, child)
+        end
+      end
+
+      def render_tig(xml, node)
+        is_bold = node.inner_html.start_with?("<b>")
+        norm_auth = is_bold ? "admittedTerm" : "preferredTerm"
+        result = GrammarParser.parse(node.inner_html)
+
+        xml.public_send(:"tbx:tig") do
+          xml.public_send(:"tbx:term") { xml << result.term }
+          xml.public_send(:"tbx:partOfSpeech", value: result.pos)
+          result.genders.each { |g| xml.public_send(:"tbx:gram", value: g, type: "gender") }
+          xml.public_send(:"tbx:normativeAuthorization", value: norm_auth)
+        end
+      end
+
+      def render_deprecated_tig(xml, node)
+        clean_html = node.inner_html.gsub(%r{<span class="sts-tbx-term-depr-label">.*?</span>}, "")
+        result = GrammarParser.parse(clean_html)
+
+        xml.public_send(:"tbx:tig") do
+          xml.public_send(:"tbx:term") { xml << result.term }
+          xml.public_send(:"tbx:partOfSpeech", value: result.pos)
+          result.genders.each { |g| xml.public_send(:"tbx:gram", value: g, type: "gender") }
+          xml.public_send(:"tbx:normativeAuthorization", value: "deprecatedTerm")
+        end
+      end
+
+      def render_definition(xml, node)
+        extracted = DomainExtractor.extract(node)
+
+        extracted.domains.each do |domain|
+          xml.public_send(:"tbx:subjectField") { xml << domain }
+        end
+
+        xml.public_send(:"tbx:definition") do
+          extracted.clean_children.each { |child| render_inline(xml, child) }
+        end
+      end
+
+      def render_note(xml, node)
+        label = node.at_css("span.sts-tbx-note-label")
+        content_node = node.at_css("div.sts-tbx-note-content") || node
+
+        xml.public_send(:"tbx:note") do
+          xml.label label.text if label
+          content_node.children.each { |child| render_inline(xml, child) }
+        end
+      end
+
+      def render_example(xml, node)
+        label = node.at_css("span.sts-tbx-example-label")
+
+        xml.public_send(:"tbx:example") do
+          xml.label label.text if label
+          node.children.each do |child|
+            next if child.classes&.include?("sts-tbx-example-label")
+
+            render_inline(xml, child)
+          end
+        end
+      end
+
+      def render_source(xml, node)
+        xml.public_send(:"tbx:source") do
+          node.children.each { |child| render_inline(xml, child) }
+        end
+      end
+    end
+  end
+end

--- a/lib/obp/access/parser.rb
+++ b/lib/obp/access/parser.rb
@@ -1,13 +1,11 @@
 module Obp
   class Access
     class Parser
-      attr_reader :urn, :directory, :language, :base_urn
+      attr_reader :urn, :directory
 
       def initialize(urn:, directory:)
         @urn = urn
         @directory = directory
-        @language = urn.split(":").last
-        @base_urn = urn.split(":")[0...-1].join(":") # urn without the language part
       end
 
       def to_xml
@@ -15,19 +13,33 @@ module Obp
       end
 
       def title
-        state.filter_map { |attr| attr["tabs"] }.first.last["description"]
+        tab_data["description"]
+      end
+
+      def html
+        @html ||= begin
+          content = state.filter_map { |attr| attr["htmlContent"] }.first
+          raise "OBP content not found for URN #{urn}" unless content
+
+          content
+        end
+      end
+
+      def available_languages
+        state
+          .select { |attr| !attr["caption"]&.empty? && attr["styles"]&.include?("toggle") }
+          .filter_map { |attr| attr["caption"] }
+          .uniq
       end
 
       private
 
-      def state
-        @state ||= begin
-          ui_response = load_ui_response
-          ui_json     = JSON.parse(ui_response.body)
-          state_json  = JSON.parse(ui_json["uidl"])
+      def fetcher
+        @fetcher ||= Fetcher.new(urn:)
+      end
 
-          state_json["state"].values
-        end
+      def state
+        @state ||= fetcher.fetch_state
       end
 
       def xml
@@ -35,58 +47,35 @@ module Obp
           metas = {
             "titles" => titles,
             "images" => images,
-            "language" => language,
-          }
-          metas.merge! state.filter_map { |attr| attr["tabs"] }.first.last
-          converter = Converter.new(urn:, metas:, source: html)
-          converter.to_xml
+            "language" => urn.language,
+          }.merge(tab_data)
+
+          Converter.new(urn:, metas:, source: html).to_xml
         end
       end
 
-      def html
-        @html ||= begin
-          html = state.filter_map { |attr| attr["htmlContent"] }.first
-          unless html
-            raise StandardError,
-                  "OBP can't by found using reference #{urn}."
-          end
-
-          html
-        end
+      def tab_data
+        @tab_data ||= state.filter_map { |attr| attr["tabs"] }.first.last
       end
 
       def titles
-        languages = get_languages_from_html
-        languages = [language] if languages.empty?
+        languages = available_languages
+        languages = [urn.language] if languages.empty?
 
-        # Parallelize translated titles fetching to speed up process
-        Parallel.map(languages) do |key|
-          if key == language
-            [key, title]
-          else
-            [key, Parser.new(urn: "#{base_urn}:#{key}", directory:).title]
-          end
-        end.to_h
+        Parallel.map(languages) { |lang| fetch_title(lang) }.to_h
+      end
+
+      def fetch_title(lang)
+        if lang == urn.language
+          [lang, title]
+        else
+          other_urn = Urn.new("#{urn.base}:#{lang}")
+          [lang, Parser.new(urn: other_urn, directory:).title]
+        end
       end
 
       def images
         Imager.new(html:, directory:).images
-      end
-
-      def load_ui_response
-        payload = {
-          "v-browserDetails" => 1,
-          "theme" => "iso-red",
-          "v-loc" => "#{API_URL}##{urn}",
-        }
-
-        Net::HTTP.post_form(URI(API_URL), payload)
-      end
-
-      def get_languages_from_html
-        state
-          .select { |attr| !attr["caption"]&.empty? && attr["styles"]&.include?("toggle") }
-          .map { |attr| attr["caption"] }.uniq
       end
     end
   end

--- a/lib/obp/access/renderer.rb
+++ b/lib/obp/access/renderer.rb
@@ -1,26 +1,3 @@
-require_relative "elements/base"
-require_relative "elements/root"
-require_relative "elements/introduction"
-require_relative "elements/section"
-require_relative "elements/figure"
-require_relative "elements/figure_group"
-require_relative "elements/list"
-require_relative "elements/array"
-require_relative "elements/table_wrap"
-require_relative "elements/title"
-require_relative "elements/paragraph"
-require_relative "elements/copyright"
-require_relative "elements/bibliography"
-require_relative "elements/terminology"
-require_relative "elements/terminology/base"
-require_relative "elements/terminology/definition"
-require_relative "elements/terminology/note"
-require_relative "elements/terminology/tig"
-require_relative "elements/terminology/tig_admitted"
-require_relative "elements/terminology/tig_preferred"
-require_relative "elements/terminology/example"
-require_relative "elements/terminology/source"
-
 module Obp
   class Access
     class Renderer
@@ -34,8 +11,8 @@ module Obp
       end
 
       def to_xml
-        nodes.map { |node| render(node:) }
-        document.to_xml
+        @nodes.each { |node| render(node:) }
+        @document.to_xml
       end
 
       private
@@ -43,34 +20,23 @@ module Obp
       def render(node:, target: nil)
         return unless css_classes_match?(node)
 
-        elements.map do |descendant|
-          element = descendant.new(document:, metas:, node:)
+        ElementRegistry.elements.each do |element_class|
+          element = element_class.new(document:, metas:, node:)
           next unless element.match_node?
 
           xml = element.render(target:)
           section_path = xml.first.path
 
-          node.children.each do |children_node|
-            # Recursively render children on an actual XML section path
-            render(node: children_node, target: section_path)
+          node.children.each do |child|
+            render(node: child, target: section_path)
           end
 
           xml
         end
       end
 
-      def elements
-        # Only Elements::Root isn't based on Elements::Base
-        @elements ||= ObjectSpace.each_object(Class).select { |klass| klass < Elements::Base }
-      end
-
-      def classes
-        @classes ||= elements.filter_map(&:classes).uniq
-      end
-
-      # Using Nokogiri ancestors node matching isn't good for performance, so just basic css classes matching is enough
       def css_classes_match?(node)
-        classes.any?(node.classes)
+        ElementRegistry.css_classes.any?(node.classes)
       end
     end
   end

--- a/lib/obp/access/retriever.rb
+++ b/lib/obp/access/retriever.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+
+module Obp
+  class Access
+    class Retriever
+      MANIFEST_FILE = "manifest.json"
+
+      attr_reader :output_dir, :catalog, :concurrency
+
+      def initialize(output_dir:, catalog:, concurrency: 4)
+        @output_dir = output_dir
+        @catalog = catalog
+        @concurrency = concurrency
+      end
+
+      def run
+        FileUtils.mkdir_p(output_dir)
+        pending = pending_deliverables
+        total = pending.size
+
+        if total.zero?
+          puts "Nothing to retrieve — all #{catalog.retrievable.size} deliverables already fetched."
+          return
+        end
+
+        puts "Retrieving #{total} deliverables to #{output_dir} (concurrency: #{concurrency})..."
+        process_all(pending, total)
+        puts "Done. Fetched #{total} documents."
+      end
+
+      private
+
+      def pending_deliverables
+        catalog.retrievable.reject { |d| manifest.key?(d.id.to_s) }
+      end
+
+      def process_all(pending, total)
+        Parallel.each_with_index(pending, in_threads: concurrency) do |deliverable, i|
+          process_one(deliverable, i + 1, total)
+        end
+      end
+
+      def process_one(deliverable, index, total)
+        deliverable.languages.each { |lang| fetch_and_save(deliverable, lang) }
+        record_success(deliverable)
+        puts "[#{index}/#{total}] #{deliverable.reference} — OK"
+      rescue StandardError => e
+        record_failure(deliverable, e)
+        puts "[#{index}/#{total}] #{deliverable.reference} — FAILED: #{e.message}"
+      end
+
+      def fetch_and_save(deliverable, language)
+        urn = deliverable.to_urn(language:)
+        access = Access.fetch(urn.to_s)
+        xml = access.to_xml(pretty: true)
+
+        dir = File.join(output_dir, deliverable.reference.gsub(%r{[/:\s]}, "-"))
+        FileUtils.mkdir_p(dir)
+        File.write(File.join(dir, "#{language}.xml"), xml)
+      end
+
+      def record_success(deliverable)
+        manifest[deliverable.id.to_s] = {
+          "reference" => deliverable.reference,
+          "status" => "success",
+          "timestamp" => Time.now.utc.iso8601,
+        }
+        save_manifest
+      end
+
+      def record_failure(deliverable, error)
+        manifest[deliverable.id.to_s] = {
+          "reference" => deliverable.reference,
+          "status" => "failed",
+          "error" => error.message,
+          "timestamp" => Time.now.utc.iso8601,
+        }
+        save_manifest
+      end
+
+      def manifest
+        @manifest ||= begin
+          path = File.join(output_dir, MANIFEST_FILE)
+          File.exist?(path) ? JSON.parse(File.read(path)) : {}
+        end
+      end
+
+      def save_manifest
+        path = File.join(output_dir, MANIFEST_FILE)
+        File.write(path, JSON.pretty_generate(manifest))
+      end
+    end
+  end
+end

--- a/lib/obp/access/urn.rb
+++ b/lib/obp/access/urn.rb
@@ -1,0 +1,31 @@
+module Obp
+  class Access
+    class Urn
+      attr_reader :raw, :language, :base
+
+      def initialize(raw)
+        @raw = raw
+        parts = raw.split(":")
+        @language = parts.last
+        @base = parts[0...-1].join(":")
+      end
+
+      def safe
+        @safe ||= raw.tr(":", "-")
+      end
+
+      def to_s
+        raw
+      end
+
+      def ==(other)
+        other.is_a?(self.class) && raw == other.raw
+      end
+      alias_method :eql?, :==
+
+      def hash
+        raw.hash
+      end
+    end
+  end
+end

--- a/obp-access.gemspec
+++ b/obp-access.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri"
   spec.add_dependency "parallel"
   spec.add_dependency "sts"
+  spec.add_dependency "thor"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/spec/obp/access/access_spec.rb
+++ b/spec/obp/access/access_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access do
+  describe ".fetch" do
+    it "accepts a languages option" do
+      urn = "iso:std:iso:5598:ed-3:v1:en"
+      parser = instance_double(Obp::Access::Parser,
+                               to_xml: "<standard/>",
+                               html: "<html/>",
+                               available_languages: %w[fr de],
+                               title: "ISO 5598")
+      allow(Obp::Access::Parser).to receive(:new).and_return(parser)
+
+      access = described_class.fetch(urn, languages: :all)
+      expect(access).to be_a(described_class)
+    end
+
+    it "raises ArgumentError without URN" do
+      expect { described_class.fetch(nil) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#to_sts" do
+    it "returns a Sts::NisoSts::Standard" do
+      xml = <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <standard xmlns:xlink="http://www.w3.org/1999/xlink"
+                  xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                  xmlns:tbx="urn:iso:std:iso:30042:ed-2">
+          <front><std-meta><permissions>
+            <copyright-statement>All rights reserved</copyright-statement>
+            <copyright-holder>ISO</copyright-holder>
+          </permissions>
+          <title-wrap xml:lang="en"><full>Test Standard</full></title-wrap>
+          <proj-id>ISO 5598</proj-id><content-language>en</content-language>
+          <std-ref type="dated">ISO 5598:2020</std-ref>
+          <std-ref type="undated">ISO 5598</std-ref>
+          <doc-ref>ISO 5598:2020</doc-ref>
+          </std-meta></front>
+          <body><sec id="sec_1"><label>1</label></sec></body>
+          <back/>
+        </standard>
+      XML
+
+      access = described_class.send(:new, Obp::Access::Urn.new("iso:std:iso:5598:ed-3:v1:en"))
+      allow(access).to receive(:primary_xml).and_return(xml)
+      allow(access).to receive(:multilingual?).and_return(false)
+
+      result = access.to_sts
+      expect(result).to be_a(Sts::NisoSts::Standard)
+      expect(result.body.sec.size).to eq(1)
+    end
+  end
+end

--- a/spec/obp/access/catalog_spec.rb
+++ b/spec/obp/access/catalog_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::Catalog do
+  let(:jsonl_content) do
+    <<~JSONL
+      {"id":1,"deliverableType":"IS","supplementType":null,"reference":"ISO 9001:2015","edition":5,"currentStage":6060,"languages":["en","fr"],"title":{"en":"Quality"},"publicationDate":"2015-09-15","icsCode":["03.120.10"],"ownerCommittee":"ISO/TC 176/SC 2"}
+      {"id":2,"deliverableType":"TS","supplementType":null,"reference":"ISO/TS 14812:2025","edition":2,"currentStage":6060,"languages":["en"],"title":{"en":"ITS vocab"},"publicationDate":"2025-01-15","icsCode":["03.220.01"],"ownerCommittee":"ISO/TC 204"}
+      {"id":3,"deliverableType":"IS","supplementType":null,"reference":"ISO 3590:1976","edition":1,"currentStage":9020,"languages":["en","fr"],"title":{"en":"Withdrawn"},"publicationDate":"1976-04-01","icsCode":["25.060.10"],"ownerCommittee":"ISO/TC 39"}
+      {"id":4,"deliverableType":"IS","supplementType":"Amd","reference":"ISO 9001:2015/Amd 1:2024","edition":5,"currentStage":6060,"languages":["en"],"title":{"en":"Amd"},"publicationDate":"2024-02-01","icsCode":["03.120.10"],"ownerCommittee":"ISO/TC 176/SC 2"}
+      {"id":5,"deliverableType":"IS","supplementType":null,"reference":"ISO 1000:1975","edition":1,"currentStage":6060,"languages":[],"title":{"en":"No langs"},"publicationDate":"1975-01-01","icsCode":[],"ownerCommittee":"ISO/TC 12"}
+    JSONL
+  end
+
+  let(:tmpfile) do
+    file = Tempfile.new(["catalog", ".jsonl"])
+    file.write(jsonl_content)
+    file.close
+    file
+  end
+
+  after { tmpfile.unlink }
+
+  describe ".load" do
+    it "loads from a local JSONL file" do
+      catalog = described_class.load(path: tmpfile.path)
+      expect(catalog.count).to eq(5)
+    end
+
+    it "creates Deliverable objects" do
+      catalog = described_class.load(path: tmpfile.path)
+      catalog.deliverables.each do |d|
+        expect(d).to be_a(Obp::Access::Deliverable)
+      end
+    end
+
+    it "skips empty lines" do
+      file = Tempfile.new(["catalog_empty", ".jsonl"])
+      file.write("\n#{jsonl_content.lines.first}\n\n")
+      file.close
+      catalog = described_class.load(path: file.path)
+      expect(catalog.count).to eq(1)
+      file.unlink
+    end
+  end
+
+  describe "#retrievable" do
+    it "returns only published base documents with languages" do
+      catalog = described_class.load(path: tmpfile.path)
+      retrievable = catalog.retrievable
+
+      refs = retrievable.map(&:reference)
+      expect(refs).to include("ISO 9001:2015", "ISO/TS 14812:2025")
+      expect(refs).not_to include("ISO 3590:1976") # stage 9020 (not published)
+      expect(refs).not_to include("ISO 9001:2015/Amd 1:2024") # supplement
+      expect(refs).not_to include("ISO 1000:1975") # no languages
+    end
+  end
+
+  describe "#by_type" do
+    it "filters by deliverable type" do
+      catalog = described_class.load(path: tmpfile.path)
+      ts = catalog.by_type("TS")
+      expect(ts.size).to eq(1)
+      expect(ts.first.reference).to eq("ISO/TS 14812:2025")
+    end
+  end
+
+  describe "#by_ics" do
+    it "filters by ICS code" do
+      catalog = described_class.load(path: tmpfile.path)
+      result = catalog.by_ics("03.120.10")
+      expect(result.size).to eq(2)
+      refs = result.map(&:reference)
+      expect(refs).to include("ISO 9001:2015", "ISO 9001:2015/Amd 1:2024")
+    end
+  end
+
+  describe "#count" do
+    it "returns total number of deliverables" do
+      catalog = described_class.load(path: tmpfile.path)
+      expect(catalog.count).to eq(5)
+    end
+  end
+end

--- a/spec/obp/access/cli_spec.rb
+++ b/spec/obp/access/cli_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::CLI do
+  subject(:cli) { described_class.new }
+
+  describe "commands" do
+    it "has fetch command" do
+      expect(described_class.all_commands).to have_key("fetch")
+    end
+
+    it "has catalog command" do
+      expect(described_class.all_commands).to have_key("catalog")
+    end
+
+    it "has retrieve command" do
+      expect(described_class.all_commands).to have_key("retrieve")
+    end
+  end
+
+  describe "#fetch" do
+    it "outputs XML to stdout" do
+      access_instance = instance_double(Obp::Access,
+                                        to_xml: "<?xml version=\"1.0\"?>\n<standard/>",
+                                        urn: Obp::Access::Urn.new("iso:std:iso:9001:ed-5:v1:en"))
+
+      allow(Obp::Access).to receive(:fetch)
+        .with("iso:std:iso:9001:ed-5:v1:en", languages: nil)
+        .and_return(access_instance)
+
+      expect { cli.fetch("iso:std:iso:9001:ed-5:v1:en") }.to output(/<standard/).to_stdout
+    end
+
+    it "saves XML to file when --output given" do
+      dir = Dir.mktmpdir("cli-test")
+      begin
+        access_instance = instance_double(Obp::Access,
+                                          to_xml: "<?xml version=\"1.0\"?>\n<standard/>",
+                                          urn: Obp::Access::Urn.new("iso:std:iso:9001:ed-5:v1:en"))
+
+        allow(Obp::Access).to receive(:fetch).and_return(access_instance)
+
+        cli_with_output = described_class.new([], { "output" => dir })
+        cli_with_output.fetch("iso:std:iso:9001:ed-5:v1:en")
+
+        expect(File.exist?(File.join(dir, "iso-std-iso-9001-ed-5-v1-en.xml"))).to be true
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    it "exits with error on failure" do
+      allow(Obp::Access).to receive(:fetch).and_raise("OBP content not found")
+
+      expect { cli.fetch("iso:std:iso:9999:ed-1:v1:en") }.to raise_error(SystemExit)
+    end
+  end
+
+  describe "#catalog" do
+    it "shows catalog summary" do
+      catalog_instance = instance_double(Obp::Access::Catalog)
+      allow(catalog_instance).to receive(:deliverables).and_return([])
+      allow(catalog_instance).to receive(:retrievable).and_return([])
+      allow(Obp::Access::Catalog).to receive(:load).and_return(catalog_instance)
+
+      expect { cli.catalog }.to output(/Total: 0/).to_stdout
+    end
+  end
+end

--- a/spec/obp/access/deliverable_spec.rb
+++ b/spec/obp/access/deliverable_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::Deliverable do
+  let(:is_data) do
+    {
+      "id" => 123,
+      "reference" => "ISO 9001:2015",
+      "deliverableType" => "IS",
+      "edition" => 5,
+      "currentStage" => 6060,
+      "languages" => %w[en fr],
+      "supplementType" => nil,
+      "title" => { "en" => "Quality management systems", "fr" => "Systèmes de management de la qualité" },
+      "publicationDate" => "2015-09-15",
+      "icsCode" => ["03.120.10"],
+      "ownerCommittee" => "ISO/TC 176/SC 2",
+    }
+  end
+
+  let(:ts_data) do
+    {
+      "id" => 456,
+      "reference" => "ISO/TS 14812:2025",
+      "deliverableType" => "TS",
+      "edition" => 2,
+      "currentStage" => 6060,
+      "languages" => ["en"],
+      "supplementType" => nil,
+      "title" => { "en" => "Intelligent transport systems" },
+      "publicationDate" => "2025-01-15",
+      "icsCode" => ["03.220.01"],
+      "ownerCommittee" => "ISO/TC 204",
+    }
+  end
+
+  let(:dual_logo_data) do
+    {
+      "id" => 789,
+      "reference" => "ISO/IEC 27001:2022",
+      "deliverableType" => "IS",
+      "edition" => 3,
+      "currentStage" => 6060,
+      "languages" => %w[en fr],
+      "supplementType" => nil,
+      "title" => { "en" => "Information security management systems" },
+      "publicationDate" => "2022-10-25",
+      "icsCode" => ["35.030"],
+      "ownerCommittee" => "ISO/IEC JTC 1/SC 27",
+    }
+  end
+
+  let(:part_data) do
+    {
+      "id" => 321,
+      "reference" => "ISO 9000-2:1993",
+      "deliverableType" => "IS",
+      "edition" => 1,
+      "currentStage" => 9599,
+      "languages" => %w[en fr],
+      "supplementType" => nil,
+      "title" => { "en" => "Quality management — Part 2" },
+      "publicationDate" => "1993-06-03",
+      "icsCode" => %w[03.120.10 03.100.70],
+      "ownerCommittee" => "ISO/TC 176/SC 2",
+    }
+  end
+
+  let(:supplement_data) do
+    {
+      "id" => 999,
+      "reference" => "ISO 9001:2015/Amd 1:2024",
+      "deliverableType" => "IS",
+      "edition" => 5,
+      "currentStage" => 6060,
+      "languages" => %w[en fr],
+      "supplementType" => "Amd",
+      "title" => { "en" => "Amendment 1" },
+      "publicationDate" => "2024-02-01",
+      "icsCode" => ["03.120.10"],
+      "ownerCommittee" => "ISO/TC 176/SC 2",
+    }
+  end
+
+  describe "attribute readers" do
+    subject(:d) { described_class.new(is_data) }
+
+    it "exposes all fields" do
+      expect(d.id).to eq(123)
+      expect(d.reference).to eq("ISO 9001:2015")
+      expect(d.deliverable_type).to eq("IS")
+      expect(d.edition).to eq(5)
+      expect(d.current_stage).to eq(6060)
+      expect(d.languages).to eq(%w[en fr])
+      expect(d.supplement_type).to be_nil
+      expect(d.title).to eq({ "en" => "Quality management systems", "fr" => "Systèmes de management de la qualité" })
+      expect(d.publication_date).to eq("2015-09-15")
+      expect(d.ics_codes).to eq(["03.120.10"])
+      expect(d.owner_committee).to eq("ISO/TC 176/SC 2")
+    end
+  end
+
+  describe "#english_title" do
+    it "returns the English title" do
+      d = described_class.new(is_data)
+      expect(d.english_title).to eq("Quality management systems")
+    end
+  end
+
+  describe "#published?" do
+    it "returns true for stage 6060" do
+      expect(described_class.new(is_data)).to be_published
+    end
+
+    it "returns true for stage 9092" do
+      data = is_data.merge("currentStage" => 9092)
+      expect(described_class.new(data)).to be_published
+    end
+
+    it "returns false for stage 9599 (withdrawn)" do
+      expect(described_class.new(part_data)).not_to be_published
+    end
+  end
+
+  describe "#base_document?" do
+    it "returns true when supplement_type is nil" do
+      expect(described_class.new(is_data)).to be_base_document
+    end
+
+    it "returns false when supplement_type is present" do
+      expect(described_class.new(supplement_data)).not_to be_base_document
+    end
+  end
+
+  describe "#retrievable?" do
+    it "returns true when published, base document, and has languages" do
+      expect(described_class.new(is_data)).to be_retrievable
+    end
+
+    it "returns false when withdrawn" do
+      expect(described_class.new(part_data)).not_to be_retrievable
+    end
+
+    it "returns false when supplement" do
+      expect(described_class.new(supplement_data)).not_to be_retrievable
+    end
+
+    it "returns false when no languages" do
+      data = is_data.merge("languages" => [])
+      expect(described_class.new(data)).not_to be_retrievable
+    end
+  end
+
+  describe "#to_urn" do
+    it "generates correct URN for plain ISO IS" do
+      urn = described_class.new(is_data).to_urn
+      expect(urn.to_s).to eq("iso:std:iso:9001:ed-5:v1:en")
+    end
+
+    it "generates correct URN for ISO/TS" do
+      urn = described_class.new(ts_data).to_urn
+      expect(urn.to_s).to eq("iso:std:iso:ts:14812:ed-2:v1:en")
+    end
+
+    it "generates correct URN for dual-logo (ISO/IEC)" do
+      urn = described_class.new(dual_logo_data).to_urn
+      expect(urn.to_s).to eq("iso:std:iso-iec:27001:ed-3:v1:en")
+    end
+
+    it "generates correct URN for document with part number" do
+      urn = described_class.new(part_data).to_urn
+      expect(urn.to_s).to eq("iso:std:iso:9000:-2:ed-1:v1:en")
+    end
+
+    it "generates correct URN for alternative language" do
+      urn = described_class.new(is_data).to_urn(language: "fr")
+      expect(urn.to_s).to eq("iso:std:iso:9001:ed-5:v1:fr")
+    end
+
+    it "strips supplement suffix from reference for URN generation" do
+      urn = described_class.new(supplement_data).to_urn
+      expect(urn.to_s).to eq("iso:std:iso:9001:ed-5:v1:en")
+    end
+
+    it "returns a Urn instance" do
+      urn = described_class.new(is_data).to_urn
+      expect(urn).to be_a(Obp::Access::Urn)
+    end
+  end
+
+  describe "edge cases" do
+    it "handles missing title gracefully" do
+      data = is_data.merge("title" => nil)
+      d = described_class.new(data)
+      expect(d.title).to eq({})
+      expect(d.english_title).to be_nil
+    end
+
+    it "handles missing languages gracefully" do
+      data = is_data.merge("languages" => nil)
+      d = described_class.new(data)
+      expect(d.languages).to eq([])
+    end
+
+    it "handles missing icsCode gracefully" do
+      data = is_data.merge("icsCode" => nil)
+      d = described_class.new(data)
+      expect(d.ics_codes).to eq([])
+    end
+  end
+end

--- a/spec/obp/access/domain_extractor_spec.rb
+++ b/spec/obp/access/domain_extractor_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::DomainExtractor do
+  def build_node(inner_html)
+    wrapped = "<div class=\"sts-tbx-def\">#{inner_html}</div>"
+    doc = Nokogiri::HTML.fragment(wrapped)
+    doc.at_css("div")
+  end
+
+  describe ".extract" do
+    it "returns empty domains when no domain markers" do
+      node = build_node("simple definition text")
+      result = described_class.extract(node)
+      expect(result.domains).to eq([])
+    end
+
+    it "extracts a single domain" do
+      node = build_node("&lt;hydraulic&gt; a fluid power system")
+      result = described_class.extract(node)
+      expect(result.domains).to eq(["hydraulic"])
+    end
+
+    it "extracts multiple domains" do
+      node = build_node("&lt;hydraulic&gt; &lt;pneumatic&gt; a system")
+      result = described_class.extract(node)
+      expect(result.domains).to eq(%w[hydraulic pneumatic])
+    end
+
+    it "returns remaining children as clean_children" do
+      node = build_node("&lt;hydraulic&gt; a fluid power system")
+      result = described_class.extract(node)
+      expect(result.clean_children).not_to be_empty
+      text = result.clean_children.first
+      expect(text.content.strip).to eq("a fluid power system")
+    end
+
+    it "skips non-text leading children" do
+      node = build_node("<b>bold definition</b>")
+      result = described_class.extract(node)
+      expect(result.domains).to eq([])
+      expect(result.clean_children.first.name).to eq("b")
+    end
+
+    it "rejects domains with parentheses" do
+      node = build_node("&lt;domain (invalid)&gt; text")
+      result = described_class.extract(node)
+      expect(result.domains).to eq([])
+    end
+
+    it "rejects domains with multi-digit numbers" do
+      node = build_node("&lt;ISO 5598&gt; text")
+      result = described_class.extract(node)
+      expect(result.domains).to eq([])
+    end
+
+    it "rejects domains longer than 50 characters" do
+      long = "a" * 51
+      node = build_node("&lt;#{long}&gt; text")
+      result = described_class.extract(node)
+      expect(result.domains).to eq([])
+    end
+
+    it "returns a Result struct" do
+      node = build_node("text")
+      result = described_class.extract(node)
+      expect(result).to be_a(Struct)
+      expect(result.members).to eq(%i[domains clean_children])
+    end
+
+    it "stops domain extraction after first non-domain text" do
+      node = build_node("not a domain &lt;hydraulic&gt; text")
+      result = described_class.extract(node)
+      expect(result.domains).to eq([])
+    end
+
+    it "handles domain followed by element child" do
+      node = build_node("&lt;hydraulic&gt; <b>bold part</b>")
+      result = described_class.extract(node)
+      expect(result.domains).to eq(["hydraulic"])
+      expect(result.clean_children.map(&:name)).to include("b")
+    end
+  end
+end

--- a/spec/obp/access/elements/figure_spec.rb
+++ b/spec/obp/access/elements/figure_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::Renderer::Elements::Figure do
+  def build_document
+    Nokogiri::XML('<standard xmlns:xlink="http://www.w3.org/1999/xlink"><body/></standard>')
+  end
+
+  def build_figure_node(html)
+    doc = Nokogiri::HTML.fragment(html)
+    doc.at_css("div")
+  end
+
+  let(:document) { build_document }
+  let(:metas) { { "images" => { "fig1.png" => "media/fig1.png" } } }
+
+  describe ".classes" do
+    it "matches sts-fig" do
+      expect(described_class.classes).to eq(%w[sts-fig])
+    end
+  end
+
+  describe "#match_node?" do
+    it "matches a sts-fig div with an image" do
+      node = build_figure_node('<div class="sts-fig"><img src="fig1.png"/></div>')
+      element = described_class.new(document: document, metas: metas, node: node)
+      expect(element.match_node?).to be true
+    end
+
+    it "does not match a sts-fig div without an image" do
+      node = build_figure_node('<div class="sts-fig"><p>text</p></div>')
+      element = described_class.new(document: document, metas: metas, node: node)
+      expect(element.match_node?).to be false
+    end
+  end
+
+  describe "#render" do
+    it "renders a figure with caption and graphic" do
+      html = <<~HTML
+        <div class="sts-fig" id="fig_1">
+          <div class="sts-caption">
+            <span class="sts-caption-label">Figure 1</span>
+            <span class="sts-caption-title">Hydraulic circuit</span>
+          </div>
+          <img src="fig1.png"/>
+        </div>
+      HTML
+      node = build_figure_node(html)
+      element = described_class.new(document: document, metas: metas, node: node)
+      element.render(target: "body")
+
+      fig = document.at_css("body fig")
+      expect(fig).not_to be_nil
+      expect(fig.at_css("label").text).to eq("Figure 1")
+      expect(fig.at_css("caption title").text).to eq("Hydraulic circuit")
+      graphic = fig.at_css("graphic")
+      expect(graphic["xlink:href"]).to eq("media/fig1.png")
+    end
+
+    it "renders a figure with a legend table" do
+      html = <<~HTML
+        <div class="sts-fig" id="fig_2">
+          <img src="fig1.png"/>
+          <div class="sts-table-wrap fig-index">
+            <div class="sts-caption">
+              <span class="sts-caption-title">Key</span>
+            </div>
+            <table><tr><td>1</td><td>pump</td></tr></table>
+          </div>
+        </div>
+      HTML
+      node = build_figure_node(html)
+      element = described_class.new(document: document, metas: metas, node: node)
+      element.render(target: "body")
+
+      fig = document.at_css("body fig")
+      legend = fig.at_css("table-wrap")
+      expect(legend).not_to be_nil
+      expect(legend["content-type"]).to eq("legend")
+      expect(legend.at_css("caption title").text).to eq("Key")
+    end
+
+    it "renders a figure without caption" do
+      html = '<div class="sts-fig" id="fig_3"><img src="fig1.png"/></div>'
+      node = build_figure_node(html)
+      element = described_class.new(document: document, metas: metas, node: node)
+      element.render(target: "body")
+
+      fig = document.at_css("body fig")
+      expect(fig).not_to be_nil
+      expect(fig.at_css("caption")).to be_nil
+      expect(fig.at_css("graphic")).not_to be_nil
+    end
+  end
+end

--- a/spec/obp/access/elements/index_spec.rb
+++ b/spec/obp/access/elements/index_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::Renderer::Elements::Index do
+  def build_document
+    Nokogiri::XML('<standard xmlns:xlink="http://www.w3.org/1999/xlink"><body/></standard>')
+  end
+
+  def build_index_node(html)
+    doc = Nokogiri::HTML.fragment(html)
+    doc.at_css("div")
+  end
+
+  let(:document) { build_document }
+  let(:metas) { {} }
+
+  describe ".classes" do
+    it "matches sts-section" do
+      expect(described_class.classes).to eq(%w[sts-section])
+    end
+  end
+
+  describe "#match_node?" do
+    it "matches a section with sec_index id" do
+      node = build_index_node('<div class="sts-section" id="sec_index"></div>')
+      element = described_class.new(document: document, metas: metas, node: node)
+      expect(element.match_node?).to be true
+    end
+
+    it "matches a section with Index title" do
+      node = build_index_node('<div class="sts-section" id="sec_other"><h1 class="sts-sec-title">Index</h1></div>')
+      element = described_class.new(document: document, metas: metas, node: node)
+      expect(element.match_node?).to be true
+    end
+
+    it "matches a section with Sachverzeichnis title" do
+      html = '<div class="sts-section" id="sec_other">' \
+             '<h1 class="sts-sec-title">Sachverzeichnis</h1></div>'
+      node = build_index_node(html)
+      element = described_class.new(document: document, metas: metas, node: node)
+      expect(element.match_node?).to be true
+    end
+
+    it "does not match a regular section" do
+      node = build_index_node('<div class="sts-section" id="sec_3"><h1 class="sts-sec-title">Terms</h1></div>')
+      element = described_class.new(document: document, metas: metas, node: node)
+      expect(element.match_node?).to be false
+    end
+
+    it "does not match nodes without sts-section class" do
+      node = build_index_node('<div class="sts-p" id="sec_index"></div>')
+      element = described_class.new(document: document, metas: metas, node: node)
+      expect(element.match_node?).to be false
+    end
+  end
+
+  describe "#render" do
+    it "renders index entries grouped by letter" do
+      html = <<~HTML
+        <div class="sts-section" id="sec_index">
+          <h1 class="sts-sec-title">Index</h1>
+          <div class="sts-p"><b>A</b></div>
+          <div class="sts-p">accumulator <a class="sts-xref" href="#iso:std:iso:5598:ed-3:v1:en:term:3.1.1">3.1.1</a></div>
+          <div class="sts-p"><b>B</b></div>
+          <div class="sts-p">block <a class="sts-xref" href="#iso:std:iso:5598:ed-3:v1:en:term:3.2.1">3.2.1</a></div>
+        </div>
+      HTML
+      node = build_index_node(html)
+      element = described_class.new(document: document, metas: metas, node: node)
+      element.render(target: "body")
+
+      body = document.at_css("body")
+      sec = body.at_css("sec")
+      expect(sec).not_to be_nil
+      expect(sec["id"]).to eq("sec_index")
+      expect(sec.at_css("title").text).to eq("Index")
+
+      divs = sec.css("index-div")
+      expect(divs.length).to eq(2)
+      expect(divs[0].at_css("title").text).to eq("A")
+      expect(divs[0].at_css("index-entry term").text).to eq("accumulator")
+      expect(divs[1].at_css("title").text).to eq("B")
+    end
+
+    it "renders xrefs with sec ref-type" do
+      html = <<~HTML
+        <div class="sts-section" id="sec_index">
+          <h1 class="sts-sec-title">Index</h1>
+          <div class="sts-p"><b>A</b></div>
+          <div class="sts-p">actuator <a class="sts-xref" href="#iso:std:iso:5598:ed-3:v1:en:term:3.1.2">3.1.2</a></div>
+        </div>
+      HTML
+      node = build_index_node(html)
+      element = described_class.new(document: document, metas: metas, node: node)
+      element.render(target: "body")
+
+      xref = document.at_css("xref")
+      expect(xref["ref-type"]).to eq("sec")
+      expect(xref["rid"]).to eq("sec_3.1.2")
+    end
+  end
+end

--- a/spec/obp/access/elements/terminology/definition_spec.rb
+++ b/spec/obp/access/elements/terminology/definition_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::Renderer::Elements::Terminology::Definition do
+  def build_document
+    Nokogiri::XML(<<~XML)
+      <standard xmlns:xlink="http://www.w3.org/1999/xlink">
+        <body>
+          <tbx:termEntry id="term_3.1.1">
+            <tbx:langSet xml:lang="en"/>
+          </tbx:termEntry>
+        </body>
+      </standard>
+    XML
+  end
+
+  def build_node(html)
+    doc = Nokogiri::HTML.fragment("<div class=\"sts-tbx-def\">#{html}</div>")
+    doc.at_css("div")
+  end
+
+  let(:document) { build_document }
+  let(:metas) { {} }
+
+  describe ".classes" do
+    it "matches sts-tbx-def" do
+      expect(described_class.classes).to eq(%w[sts-tbx-def])
+    end
+  end
+
+  describe "#match_node?" do
+    it "matches a sts-tbx-def div" do
+      node = build_node("a device that moves fluid")
+      element = described_class.new(document: document, metas: metas, node: node)
+      expect(element.match_node?).to be true
+    end
+  end
+end

--- a/spec/obp/access/elements/terminology/tig_spec.rb
+++ b/spec/obp/access/elements/terminology/tig_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::Renderer::Elements::Terminology::Tig do
+  def build_document
+    Nokogiri::XML(<<~XML)
+      <standard xmlns:xlink="http://www.w3.org/1999/xlink">
+        <body>
+          <tbx:termEntry id="term_3.1.1">
+            <tbx:langSet xml:lang="en"/>
+          </tbx:termEntry>
+        </body>
+      </standard>
+    XML
+  end
+
+  def build_node(inner_html)
+    doc = Nokogiri::HTML.fragment(<<~HTML)
+      <div class="sts-tbx-sec">
+        <div class="sts-tbx-label">3.1.1</div>
+        <div class="sts-tbx-term">#{inner_html}</div>
+      </div>
+    HTML
+    doc.at_css("div.sts-tbx-term")
+  end
+
+  let(:document) { build_document }
+  let(:metas) { {} }
+
+  describe ".classes" do
+    it "matches sts-tbx-term" do
+      expect(described_class.classes).to eq(%w[sts-tbx-term])
+    end
+  end
+
+  describe "#match_node?" do
+    it "matches a sts-tbx-term div" do
+      node = build_node("pump")
+      element = described_class.new(document: document, metas: metas, node: node)
+      expect(element.match_node?).to be true
+    end
+  end
+end
+
+RSpec.describe Obp::Access::Renderer::Elements::Terminology::TigPreferred do
+  describe ".classes" do
+    it "matches sts-tbx-term preferredTerm" do
+      expect(described_class.classes).to eq(%w[sts-tbx-term preferredTerm])
+    end
+  end
+end
+
+RSpec.describe Obp::Access::Renderer::Elements::Terminology::TigAdmitted do
+  describe ".classes" do
+    it "matches sts-tbx-term admittedTerm" do
+      expect(described_class.classes).to eq(%w[sts-tbx-term admittedTerm])
+    end
+  end
+end

--- a/spec/obp/access/grammar_parser_spec.rb
+++ b/spec/obp/access/grammar_parser_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::GrammarParser do
+  describe ".parse" do
+    it "extracts a plain noun term" do
+      result = described_class.parse("pump")
+      expect(result.term).to eq("pump")
+      expect(result.pos).to eq("noun")
+      expect(result.genders).to eq([])
+    end
+
+    it "extracts an adjective term" do
+      result = described_class.parse("<b>adj.</b> hydraulic")
+      expect(result.term).to eq("hydraulic")
+      expect(result.pos).to eq("adjective")
+    end
+
+    it "extracts uppercase Adj. as adjective" do
+      result = described_class.parse("<b>Adj.</b> hydraulisch")
+      expect(result.term).to eq("hydraulisch")
+      expect(result.pos).to eq("adjective")
+    end
+
+    it "extracts a verb term" do
+      result = described_class.parse("<b>verb</b> to pump")
+      expect(result.term).to eq("to pump")
+      expect(result.pos).to eq("verb")
+    end
+
+    it "extracts a single gender" do
+      result = described_class.parse("<b>m</b> Kolben")
+      expect(result.term).to eq("Kolben")
+      expect(result.genders).to eq(["m"])
+    end
+
+    it "extracts feminine gender" do
+      result = described_class.parse("<b>f</b> pompe")
+      expect(result.term).to eq("pompe")
+      expect(result.genders).to eq(["f"])
+    end
+
+    it "extracts neuter gender" do
+      result = described_class.parse("<b>n</b> Ventil")
+      expect(result.term).to eq("Ventil")
+      expect(result.genders).to eq(["n"])
+    end
+
+    it "extracts gender with trailing comma" do
+      result = described_class.parse("<b>m,</b> <b>f</b> druck")
+      expect(result.genders).to eq(%w[m f])
+    end
+
+    it "extracts multiple genders in one bold tag" do
+      result = described_class.parse("<b>m, n</b> Gehäuse")
+      expect(result.term).to eq("Gehäuse")
+      expect(result.genders).to eq(%w[m n])
+    end
+
+    it "extracts gender with qualifier text" do
+      result = described_class.parse("<b>m normal</b> Druck")
+      expect(result.term).to eq("Druck")
+      expect(result.genders).to eq(["m"])
+    end
+
+    it "extracts gender from term_with_gender pattern" do
+      result = described_class.parse("<b>Zustand, m</b>")
+      expect(result.term).to eq("Zustand")
+      expect(result.genders).to eq(["m"])
+    end
+
+    it "deduplicates genders" do
+      result = described_class.parse("<b>m</b> <b>m</b> Kolben")
+      expect(result.genders).to eq(["m"])
+    end
+
+    it "handles bold term text (not grammar)" do
+      result = described_class.parse("<b>hydraulic pump</b>")
+      expect(result.term).to eq("hydraulic pump")
+      expect(result.pos).to eq("noun")
+      expect(result.genders).to eq([])
+    end
+
+    it "handles angle brackets to skip content" do
+      result = described_class.parse("<b>〈</b>singular<b>〉</b> Pumpe")
+      expect(result.term).to eq("Pumpe")
+    end
+
+    it "handles comma in bold as skip" do
+      result = described_class.parse("Pumpe<b>,</b> <b>f</b>")
+      expect(result.term).to eq("Pumpe")
+      expect(result.genders).to eq(["f"])
+    end
+
+    it "combines POS and gender" do
+      result = described_class.parse("<b>adj.</b> <b>m</b> hydraulischer")
+      expect(result.term).to eq("hydraulischer")
+      expect(result.pos).to eq("adjective")
+      expect(result.genders).to eq(["m"])
+    end
+
+    it "combines POS and multiple genders" do
+      result = described_class.parse("<b>adj.</b> <b>m, f</b> pompe hydraulique")
+      expect(result.term).to eq("pompe hydraulique")
+      expect(result.pos).to eq("adjective")
+      expect(result.genders).to eq(%w[m f])
+    end
+
+    it "strips trailing commas from term" do
+      result = described_class.parse("pump,")
+      expect(result.term).to eq("pump")
+    end
+
+    it "normalizes whitespace in term" do
+      result = described_class.parse("hydraulic   pump")
+      expect(result.term).to eq("hydraulic pump")
+    end
+
+    it "returns a Result struct" do
+      result = described_class.parse("pump")
+      expect(result).to be_a(Struct)
+      expect(result.members).to eq(%i[term pos genders])
+    end
+  end
+end

--- a/spec/obp/access/inline_renderer_spec.rb
+++ b/spec/obp/access/inline_renderer_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::InlineRenderer do
+  let(:dummy_class) do
+    Class.new do
+      include Obp::Access::InlineRenderer
+
+      def build_xml(&)
+        builder = Nokogiri::XML::Builder.new do |xml|
+          xml.root(&)
+        end
+        builder.doc.root
+      end
+    end
+  end
+
+  let(:renderer) { dummy_class.new }
+
+  describe "#inline_type" do
+    it "returns :text for text nodes" do
+      node = Nokogiri::HTML.fragment("hello").children.first
+      expect(renderer.inline_type(node)).to eq(:text)
+    end
+
+    it "returns :entailed_term for sts-tbx-entailedTerm" do
+      html = '<span class="sts-tbx-entailedTerm">' \
+             '<a href="#iso:std:iso:5598:ed-3:v1:en:term:3.2.2">term</a></span>'
+      node = Nokogiri::HTML.fragment(html).children.first
+      expect(renderer.inline_type(node)).to eq(:entailed_term)
+    end
+
+    it "returns :xref for sts-xref" do
+      html = '<a class="sts-xref" ' \
+             'href="#iso:std:iso:5598:ed-3:v1:en:sec:3.2">Clause 3.2</a>'
+      node = Nokogiri::HTML.fragment(html).children.first
+      expect(renderer.inline_type(node)).to eq(:xref)
+    end
+
+    it "returns :std_ref for sts-std-ref" do
+      node = Nokogiri::HTML.fragment('<span class="sts-std-ref">ISO 5598</span>').children.first
+      expect(renderer.inline_type(node)).to eq(:std_ref)
+    end
+
+    it "returns :italic for <i> tags" do
+      node = Nokogiri::HTML.fragment("<i>italic text</i>").children.first
+      expect(renderer.inline_type(node)).to eq(:italic)
+    end
+
+    it "returns :bold for <b> tags" do
+      node = Nokogiri::HTML.fragment("<b>bold text</b>").children.first
+      expect(renderer.inline_type(node)).to eq(:bold)
+    end
+
+    it "returns :ext_link for <a> tags" do
+      node = Nokogiri::HTML.fragment('<a href="http://example.com">link</a>').children.first
+      expect(renderer.inline_type(node)).to eq(:ext_link)
+    end
+
+    it "returns :label for sts-label" do
+      node = Nokogiri::HTML.fragment('<span class="sts-label">1)</span>').children.first
+      expect(renderer.inline_type(node)).to eq(:label)
+    end
+
+    it "returns :element for unknown elements" do
+      node = Nokogiri::HTML.fragment("<span>generic</span>").children.first
+      expect(renderer.inline_type(node)).to eq(:element)
+    end
+  end
+
+  describe "#xref_ref_type" do
+    it "returns 'fig' for Figure references" do
+      expect(renderer.xref_ref_type("Figure 1")).to eq("fig")
+    end
+
+    it "returns 'table' for Table references" do
+      expect(renderer.xref_ref_type("Table 2")).to eq("table")
+    end
+
+    it "returns 'sec' for Clause references" do
+      expect(renderer.xref_ref_type("Clause 3")).to eq("sec")
+    end
+
+    it "returns 'fn' for Note references" do
+      expect(renderer.xref_ref_type("Note 1")).to eq("fn")
+    end
+
+    it "defaults to 'sec'" do
+      expect(renderer.xref_ref_type("something else")).to eq("sec")
+    end
+  end
+
+  describe "#render_inline" do
+    it "renders plain text" do
+      node = Nokogiri::HTML.fragment("hello world").children.first
+      result = renderer.build_xml { |xml| renderer.render_inline(xml, node) }
+      expect(result.text).to eq("hello world")
+    end
+
+    it "renders italic" do
+      node = Nokogiri::HTML.fragment("<i>emphasis</i>").children.first
+      result = renderer.build_xml { |xml| renderer.render_inline(xml, node) }
+      expect(result.at_css("italic").text).to eq("emphasis")
+    end
+
+    it "renders bold" do
+      node = Nokogiri::HTML.fragment("<b>strong</b>").children.first
+      result = renderer.build_xml { |xml| renderer.render_inline(xml, node) }
+      expect(result.at_css("bold").text).to eq("strong")
+    end
+
+    it "skips label nodes" do
+      node = Nokogiri::HTML.fragment('<span class="sts-label">1)</span>').children.first
+      result = renderer.build_xml { |xml| renderer.render_inline(xml, node) }
+      expect(result.children.length).to eq(0)
+    end
+
+    it "renders nested inline elements" do
+      node = Nokogiri::HTML.fragment("<b>bold <i>and italic</i></b>").children.first
+      result = renderer.build_xml { |xml| renderer.render_inline(xml, node) }
+      expect(result.at_css("bold").text).to eq("bold and italic")
+      expect(result.at_css("bold italic").text).to eq("and italic")
+    end
+
+    it "renders xref with correct ref-type" do
+      html = '<a class="sts-xref" href="#iso:std:iso:5598:ed-3:v1:en:sec:3.2">Clause 3.2</a>'
+      node = Nokogiri::HTML.fragment(html).children.first
+      result = renderer.build_xml { |xml| renderer.render_inline(xml, node) }
+      xref = result.at_css("xref")
+      expect(xref["ref-type"]).to eq("sec")
+      expect(xref["rid"]).to eq("sec_3.2")
+    end
+  end
+end

--- a/spec/obp/access/multilingual_merger_spec.rb
+++ b/spec/obp/access/multilingual_merger_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::MultilingualMerger do
+  def build_primary_document
+    Nokogiri::XML(<<~XML)
+      <standard xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:tbx="urn:iso:std:iso:30042:ed-2">
+        <body>
+          <tbx:termEntry id="term_3.1.1">
+            <tbx:langSet xml:lang="en">
+              <tbx:tig>
+                <tbx:term>pump</tbx:term>
+                <tbx:partOfSpeech value="noun"/>
+              </tbx:tig>
+            </tbx:langSet>
+          </tbx:termEntry>
+        </body>
+      </standard>
+    XML
+  end
+
+  def build_fr_html
+    <<~HTML
+      <html><body>
+        <div class="sts-standard">
+          <div class="sts-section sts-tbx-sec">
+            <div class="sts-tbx-label">3.1.1</div>
+            <div class="sts-tbx-term"><b>f</b> pompe</div>
+            <div class="sts-tbx-def">dispositif de transfert de fluide</div>
+          </div>
+        </div>
+      </body></html>
+    HTML
+  end
+
+  def build_de_html
+    <<~HTML
+      <html><body>
+        <div class="sts-standard">
+          <div class="sts-section sts-tbx-sec">
+            <div class="sts-tbx-label">3.1.1</div>
+            <div class="sts-tbx-term"><b>f</b> Pumpe</div>
+            <div class="sts-tbx-def">Fluidfördermaschine</div>
+          </div>
+        </div>
+      </body></html>
+    HTML
+  end
+
+  describe "#merge" do
+    it "merges additional language langSets into primary document" do
+      doc = build_primary_document
+      merger = described_class.new(doc, { "fr" => build_fr_html }, {})
+      result = merger.merge
+
+      entry = result.at_xpath("//*[local-name()='termEntry' and @id='term_3.1.1']")
+      lang_sets = entry.xpath("./*[local-name()='langSet']")
+      expect(lang_sets.length).to eq(2)
+
+      fr_lang = lang_sets.last
+      expect(fr_lang["xml:lang"]).to eq("fr")
+
+      tigs = fr_lang.xpath("./*[local-name()='tig']")
+      expect(tigs.length).to eq(1)
+      term = tigs.first.xpath("./*[local-name()='term']").first
+      expect(term.text).to eq("pompe")
+
+      gram = tigs.first.xpath("./*[local-name()='gram']").first
+      expect(gram["value"]).to eq("f")
+      expect(gram["type"]).to eq("gender")
+    end
+
+    it "merges multiple languages" do
+      doc = build_primary_document
+      merger = described_class.new(doc, { "fr" => build_fr_html, "de" => build_de_html }, {})
+      result = merger.merge
+
+      entry = result.at_xpath("//*[local-name()='termEntry' and @id='term_3.1.1']")
+      lang_sets = entry.xpath("./*[local-name()='langSet']")
+      expect(lang_sets.length).to eq(3)
+    end
+
+    it "returns the modified document" do
+      doc = build_primary_document
+      merger = described_class.new(doc, {}, {})
+      expect(merger.merge).to equal(doc)
+    end
+
+    it "skips languages with no standard div" do
+      doc = build_primary_document
+      merger = described_class.new(doc, { "fr" => "<html><body></body></html>" }, {})
+      result = merger.merge
+
+      entry = result.at_xpath("//*[local-name()='termEntry' and @id='term_3.1.1']")
+      lang_sets = entry.xpath("./*[local-name()='langSet']")
+      expect(lang_sets.length).to eq(1)
+    end
+
+    it "skips terms not found in primary document" do
+      html = <<~HTML
+        <html><body>
+          <div class="sts-standard">
+            <div class="sts-section sts-tbx-sec">
+              <div class="sts-tbx-label">9.9.9</div>
+              <div class="sts-tbx-term">inconnu</div>
+            </div>
+          </div>
+        </body></html>
+      HTML
+      doc = build_primary_document
+      merger = described_class.new(doc, { "fr" => html }, {})
+      result = merger.merge
+
+      entry = result.at_xpath("//*[local-name()='termEntry' and @id='term_3.1.1']")
+      lang_sets = entry.xpath("./*[local-name()='langSet']")
+      expect(lang_sets.length).to eq(1)
+    end
+  end
+end

--- a/spec/obp/access/retriever_spec.rb
+++ b/spec/obp/access/retriever_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::Retriever do
+  let(:deliverables) do
+    [
+      Obp::Access::Deliverable.new(
+        "id" => 1,
+        "deliverableType" => "IS",
+        "supplementType" => nil,
+        "reference" => "ISO 9001:2015",
+        "edition" => 5,
+        "currentStage" => 6060,
+        "languages" => %w[en],
+        "title" => { "en" => "Quality" },
+        "publicationDate" => "2015-09-15",
+        "icsCode" => ["03.120.10"],
+        "ownerCommittee" => "ISO/TC 176/SC 2",
+      ),
+    ]
+  end
+
+  let(:catalog) do
+    instance_double(Obp::Access::Catalog, retrievable: deliverables)
+  end
+
+  let(:output_dir) { Dir.mktmpdir("retriever-test") }
+
+  after { FileUtils.rm_rf(output_dir) }
+
+  describe "#run" do
+    it "creates output directory" do
+      new_dir = File.join(output_dir, "nested")
+      retriever = described_class.new(output_dir: new_dir, catalog:)
+      allow(Obp::Access).to receive(:fetch).and_return(
+        instance_double(Obp::Access, to_xml: "<standard/>", urn: Obp::Access::Urn.new("iso:std:iso:9001:ed-5:v1:en")),
+      )
+
+      retriever.run
+      expect(Dir.exist?(new_dir)).to be true
+    end
+
+    it "skips already-fetched deliverables" do
+      manifest = { "1" => { "reference" => "ISO 9001:2015", "status" => "success" } }
+      File.write(File.join(output_dir, "manifest.json"), JSON.generate(manifest))
+
+      retriever = described_class.new(output_dir:, catalog:)
+      retriever.run
+
+      # Should not attempt another fetch
+      expect(File.read(File.join(output_dir, "manifest.json"))).to include("success")
+    end
+
+    it "writes manifest with success on fetch" do
+      access_instance = instance_double(Obp::Access,
+                                        to_xml: "<?xml version=\"1.0\"?>\n<standard/>",
+                                        urn: Obp::Access::Urn.new("iso:std:iso:9001:ed-5:v1:en"))
+
+      allow(Obp::Access).to receive(:fetch).with("iso:std:iso:9001:ed-5:v1:en").and_return(access_instance)
+
+      retriever = described_class.new(output_dir:, catalog:, concurrency: 1)
+      retriever.run
+
+      manifest = JSON.parse(File.read(File.join(output_dir, "manifest.json")))
+      expect(manifest["1"]["status"]).to eq("success")
+      expect(manifest["1"]["reference"]).to eq("ISO 9001:2015")
+    end
+
+    it "writes manifest with failure on error" do
+      allow(Obp::Access).to receive(:fetch).and_raise("OBP content not found")
+
+      retriever = described_class.new(output_dir:, catalog:, concurrency: 1)
+      retriever.run
+
+      manifest = JSON.parse(File.read(File.join(output_dir, "manifest.json")))
+      expect(manifest["1"]["status"]).to eq("failed")
+      expect(manifest["1"]["error"]).to eq("OBP content not found")
+    end
+
+    it "saves XML files per language" do
+      multi_lang_data = {
+        "id" => 2,
+        "deliverableType" => "IS",
+        "supplementType" => nil,
+        "reference" => "ISO 1000:1975",
+        "edition" => 1,
+        "currentStage" => 6060,
+        "languages" => %w[en fr],
+        "title" => { "en" => "Units", "fr" => "Unités" },
+        "publicationDate" => "1975-01-01",
+        "icsCode" => [],
+        "ownerCommittee" => "ISO/TC 12",
+      }
+      multi_catalog = instance_double(Obp::Access::Catalog,
+                                      retrievable: [Obp::Access::Deliverable.new(multi_lang_data)])
+
+      allow(Obp::Access).to receive(:fetch) do |urn|
+        urn_obj = Obp::Access::Urn.new(urn)
+        instance_double(Obp::Access,
+                        to_xml: "<?xml version=\"1.0\"?>\n<standard lang=\"#{urn_obj.language}\"/>",
+                        urn: urn_obj)
+      end
+
+      retriever = described_class.new(output_dir:, catalog: multi_catalog, concurrency: 1)
+      retriever.run
+
+      dir = File.join(output_dir, "ISO-1000-1975")
+      expect(File.exist?(File.join(dir, "en.xml"))).to be true
+      expect(File.exist?(File.join(dir, "fr.xml"))).to be true
+    end
+  end
+end

--- a/spec/obp/access/urn_spec.rb
+++ b/spec/obp/access/urn_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Obp::Access::Urn do
+  describe "#initialize" do
+    it "parses language and base from raw URN" do
+      urn = described_class.new("iso:std:iso:ts:14812:ed-2:v1:en")
+
+      expect(urn.raw).to eq("iso:std:iso:ts:14812:ed-2:v1:en")
+      expect(urn.language).to eq("en")
+      expect(urn.base).to eq("iso:std:iso:ts:14812:ed-2:v1")
+    end
+
+    it "handles single-segment URN" do
+      urn = described_class.new("en")
+
+      expect(urn.language).to eq("en")
+      expect(urn.base).to eq("")
+    end
+  end
+
+  describe "#safe" do
+    it "replaces colons with dashes" do
+      urn = described_class.new("iso:std:iso:9001:ed-5:v1:en")
+      expect(urn.safe).to eq("iso-std-iso-9001-ed-5-v1-en")
+    end
+  end
+
+  describe "#to_s" do
+    it "returns raw URN" do
+      urn = described_class.new("iso:std:iso:9001:ed-5:v1:en")
+      expect(urn.to_s).to eq("iso:std:iso:9001:ed-5:v1:en")
+    end
+  end
+
+  describe "equality" do
+    it "considers same URN equal" do
+      a = described_class.new("iso:std:iso:9001:ed-5:v1:en")
+      b = described_class.new("iso:std:iso:9001:ed-5:v1:en")
+      expect(a).to eq(b)
+    end
+
+    it "considers different URNs unequal" do
+      a = described_class.new("iso:std:iso:9001:ed-5:v1:en")
+      b = described_class.new("iso:std:iso:9001:ed-5:v1:fr")
+      expect(a).not_to eq(b)
+    end
+
+    it "hashes equal URNs to same value" do
+      a = described_class.new("iso:std:iso:9001:ed-5:v1:en")
+      b = described_class.new("iso:std:iso:9001:ed-5:v1:en")
+      expect(a.hash).to eq(b.hash)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "tempfile"
+require "obp/access"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
## Summary

This PR adds multilingual terminology support to obp-access, enabling generation of NISO STS XML with multiple language langSets from a single document URN.

### Core Infrastructure
- **Urn value object** for structured URN parsing (language, base)
- **Fetcher** extracted from Parser for HTTP concerns
- **ElementRegistry** replaces ObjectSpace for explicit element discovery
- **InlineRenderer** module shared across 4+ elements (DRY)

### Multilingual Features
- **GrammarParser** extracts gender (m/f/n) and POS (adj/noun/verb) from OBP HTML bold tags
- **DomainExtractor** extracts `<domain>` markers from definition text
- **MultilingualMerger** merges additional language langSets into primary document
- **TigDeprecated** with language-agnostic deprecation label stripping
- `languages:` option on `Access.fetch` — accepts `nil`, `:all`, or `['fr', 'de']`
- CLI `--languages` flag (`-l all` or `-l fr,de`)

### Element Improvements
- **Index** element for alphabetical index sections
- **Figure** legend rendering (fig-index tables)
- **TableWrap** skips rendering when inside Figure
- **Root** uses standard TBX namespace (`urn:iso:std:iso:30042:ed-2`) for sts gem compatibility
- `to_sts` now uses merged multilingual XML

### Testing
126 RSpec examples covering all new and existing features — zero failures, zero rubocop offenses.

### Usage

```ruby
# Single language
obp = Obp::Access.fetch("iso:std:iso:5598:ed-3:v1:en")
obp.to_xml(pretty: true)

# All languages
obp = Obp::Access.fetch("iso:std:iso:5598:ed-3:v1:en", languages: :all)
obp.to_xml(pretty: true)

# CLI
obp-access fetch -l all iso:std:iso:5598:ed-3:v1:en
```